### PR TITLE
Flutter/feature 158 Confirm Dialog

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -50,13 +50,7 @@ void _runApp() {
             } else {
               // Not loggedIn pop context to login screen.
               Routes.goHome(context);
-              return GirafConfirmDialog(
-                title: 'Log ud@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@',
-                description: 'Vil du logge ud?@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@',
-                confirmButtonText: 'Log ud psijf pisdjfpisjpisfj pisdjpisjdpifjspid asjdp apisjd pai djapis djpiadj piasjdpiajdpias ijapsijd apsijd paijd pa',
-                confirmButtonIcon: ImageIcon(AssetImage('assets/icons/logout.png')),
-                confirmOnPressed: () => Routes.pop(context),
-              );
+              return LoginScreen();
             }
           })));
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:weekplanner/providers/environment_provider.dart' as environment;
 import 'package:weekplanner/routes.dart';
 import 'package:weekplanner/screens/choose_citizen_screen.dart';
 import 'package:weekplanner/screens/login_screen.dart';
+import 'package:weekplanner/widgets/giraf_confirm_dialog.dart';
 
 void main() {
   // Register all dependencies for injector
@@ -49,7 +50,13 @@ void _runApp() {
             } else {
               // Not loggedIn pop context to login screen.
               Routes.goHome(context);
-              return LoginScreen();
+              return GirafConfirmDialog(
+                title: 'Log ud@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@',
+                description: 'Vil du logge ud?@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@',
+                confirmButtonText: 'Log ud psijf pisdjfpisjpisfj pisdjpisjdpifjspid asjdp apisjd pai djapis djpiadj piasjdpiajdpias ijapsijd apsijd paijd pa',
+                confirmButtonIcon: ImageIcon(AssetImage('assets/icons/logout.png')),
+                confirmOnPressed: () => Routes.pop(context),
+              );
             }
           })));
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,7 +6,6 @@ import 'package:weekplanner/providers/environment_provider.dart' as environment;
 import 'package:weekplanner/routes.dart';
 import 'package:weekplanner/screens/choose_citizen_screen.dart';
 import 'package:weekplanner/screens/login_screen.dart';
-import 'package:weekplanner/widgets/giraf_confirm_dialog.dart';
 
 void main() {
   // Register all dependencies for injector

--- a/lib/widgets/giraf_confirm_dialog.dart
+++ b/lib/widgets/giraf_confirm_dialog.dart
@@ -3,8 +3,11 @@ import 'package:flutter/material.dart';
 import 'package:weekplanner/routes.dart';
 import 'package:weekplanner/widgets/giraf_title_header.dart';
 
-class GirafConfirmDialog extends StatelessWidget
-    implements PreferredSizeWidget {
+///A dialog widget presented to the user to confirm an action, such as
+///logging out or deleting a weekplan. The dialog consists of a title,
+///a description, and two buttons. One button to cancel the action and
+///one button to accept and perform the action.
+class GirafConfirmDialog extends StatelessWidget {
   ///The dialog displays the title and description, with two buttons
   ///to either confirm the action, or cancel, which simply closes the dialog.
   const GirafConfirmDialog(
@@ -15,9 +18,6 @@ class GirafConfirmDialog extends StatelessWidget
       @required this.confirmButtonIcon,
       @required this.confirmOnPressed})
       : super(key: key);
-
-  @override
-  Size get preferredSize => const Size.fromHeight(56.0);
 
   ///title of the dialogBox, displayed in the header of the dialogBox
   final String title;
@@ -115,7 +115,7 @@ class GirafConfirmDialog extends StatelessWidget
                       ),
                     ),
                     onPressed: () {
-
+                      confirmOnPressed();
                     })
               ],
             ),

--- a/lib/widgets/giraf_confirm_dialog.dart
+++ b/lib/widgets/giraf_confirm_dialog.dart
@@ -1,0 +1,127 @@
+import 'package:auto_size_text/auto_size_text.dart';
+import 'package:flutter/material.dart';
+import 'package:weekplanner/routes.dart';
+import 'package:weekplanner/widgets/giraf_title_header.dart';
+
+class GirafConfirmDialog extends StatelessWidget
+    implements PreferredSizeWidget {
+  ///The dialog displays the title and description, with two buttons
+  ///to either confirm the action, or cancel, which simply closes the dialog.
+  const GirafConfirmDialog(
+      {Key key,
+      @required this.title,
+      this.description,
+      @required this.confirmButtonText,
+      @required this.confirmButtonIcon,
+      @required this.confirmOnPressed})
+      : super(key: key);
+
+  @override
+  Size get preferredSize => const Size.fromHeight(56.0);
+
+  ///title of the dialogBox, displayed in the header of the dialogBox
+  final String title;
+
+  ///description of the dialogBox, displayed under the header, describing the
+  ///encountered problem
+  final String description;
+
+  ///text on the confirm button, describing the confirmed action
+  final String confirmButtonText;
+
+  ///icon on the confirm button, visualizing the confirmed action
+  final ImageIcon confirmButtonIcon;
+
+  ///the method to call when the confirmation button is pressed
+  final VoidCallback confirmOnPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      contentPadding: const EdgeInsets.all(0.0),
+      titlePadding: const EdgeInsets.all(0.0),
+      shape:
+          Border.all(color: const Color.fromRGBO(112, 112, 112, 1), width: 5.0),
+      title: Center(
+          child: GirafTitleHeader(
+        title: title,
+      )),
+      content: Column(
+        mainAxisAlignment: MainAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: <Widget>[
+              Expanded(
+                  child: Padding(
+                padding: const EdgeInsets.fromLTRB(20, 10, 20, 0),
+                child: Text(
+                  //if description is null, its replaced with empty.
+                  description ?? '',
+                  textAlign: TextAlign.center,
+                ),
+              ))
+            ],
+          ),
+          Padding(
+            padding: const EdgeInsets.only(bottom: 0),
+            child: ButtonBar(
+              mainAxisSize: MainAxisSize.min,
+              alignment: MainAxisAlignment.center,
+              children: <Widget>[
+                RaisedButton(
+                    key: const Key('ConfirmDialogCancelButton'),
+                    shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(10.0),
+                        side: const BorderSide(
+                            color: Color.fromRGBO(0, 0, 0, 0.3))),
+                    color: const Color.fromRGBO(255, 157, 0, 1),
+                    child: Row(
+                      children: const <Widget>[
+                        ImageIcon(
+                          AssetImage('assets/icons/cancel.png'),
+                          color: Color.fromRGBO(0, 0, 0, 1),
+                        ),
+                        Text(
+                          'Fortryd',
+                          style: TextStyle(color: Colors.white),
+                        ),
+                      ],
+                    ),
+                    onPressed: () {
+                      Routes.pop(context);
+                    }),
+                RaisedButton(
+                    key: const Key('ConfirmDialogConfirmButton'),
+                    shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(10.0),
+                        side: const BorderSide(
+                            color: Color.fromRGBO(0, 0, 0, 0.3))),
+                    color: const Color.fromRGBO(255, 157, 0, 1),
+                    child: Center(
+                      child: Row(
+                        children: <Widget>[
+                          confirmButtonIcon,
+                          Container(
+                            child: AutoSizeText(
+                              confirmButtonText,
+                              style: const TextStyle(color: Colors.white),
+                              maxLines: 10,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    onPressed: () {
+
+                    })
+              ],
+            ),
+          )
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/giraf_confirm_dialog.dart
+++ b/lib/widgets/giraf_confirm_dialog.dart
@@ -1,10 +1,8 @@
-import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 import 'package:weekplanner/routes.dart';
 import 'package:weekplanner/widgets/giraf_title_header.dart';
 
-class GirafConfirmDialog extends StatelessWidget
-    implements PreferredSizeWidget {
+class GirafConfirmDialog extends StatelessWidget {
   ///The dialog displays the title and description, with two buttons
   ///to either confirm the action, or cancel, which simply closes the dialog.
   const GirafConfirmDialog(
@@ -15,9 +13,6 @@ class GirafConfirmDialog extends StatelessWidget
       @required this.confirmButtonIcon,
       @required this.confirmOnPressed})
       : super(key: key);
-
-  @override
-  Size get preferredSize => const Size.fromHeight(56.0);
 
   ///title of the dialogBox, displayed in the header of the dialogBox
   final String title;
@@ -66,57 +61,68 @@ class GirafConfirmDialog extends StatelessWidget
             ],
           ),
           Padding(
-            padding: const EdgeInsets.only(bottom: 0),
-            child: ButtonBar(
+            padding: const EdgeInsets.fromLTRB(10, 5, 10, 10),
+            child: Row(
               mainAxisSize: MainAxisSize.min,
-              alignment: MainAxisAlignment.center,
               children: <Widget>[
-                RaisedButton(
-                    key: const Key('ConfirmDialogCancelButton'),
-                    shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(10.0),
-                        side: const BorderSide(
-                            color: Color.fromRGBO(0, 0, 0, 0.3))),
-                    color: const Color.fromRGBO(255, 157, 0, 1),
-                    child: Row(
-                      children: const <Widget>[
-                        ImageIcon(
-                          AssetImage('assets/icons/cancel.png'),
-                          color: Color.fromRGBO(0, 0, 0, 1),
-                        ),
-                        Text(
-                          'Fortryd',
-                          style: TextStyle(color: Colors.white),
-                        ),
-                      ],
-                    ),
-                    onPressed: () {
-                      Routes.pop(context);
-                    }),
-                RaisedButton(
-                    key: const Key('ConfirmDialogConfirmButton'),
-                    shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(10.0),
-                        side: const BorderSide(
-                            color: Color.fromRGBO(0, 0, 0, 0.3))),
-                    color: const Color.fromRGBO(255, 157, 0, 1),
-                    child: Center(
-                      child: Row(
-                        children: <Widget>[
-                          confirmButtonIcon,
-                          Container(
-                            child: AutoSizeText(
-                              confirmButtonText,
-                              style: const TextStyle(color: Colors.white),
-                              maxLines: 10,
+                Flexible(
+                  fit: FlexFit.loose,
+                  child: Padding(
+                    padding: const EdgeInsets.only(right: 5),
+                    child: RaisedButton(
+                        key: const Key('ConfirmDialogCancelButton'),
+                        shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(10.0),
+                            side: const BorderSide(
+                                color: Color.fromRGBO(0, 0, 0, 0.3))),
+                        color: const Color.fromRGBO(255, 157, 0, 1),
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: const <Widget>[
+                            ImageIcon(
+                              AssetImage('assets/icons/cancel.png'),
+                              color: Color.fromRGBO(0, 0, 0, 1),
                             ),
-                          ),
-                        ],
-                      ),
-                    ),
-                    onPressed: () {
-
-                    })
+                            Text(
+                              'Fortryd',
+                              style: TextStyle(color: Colors.white),
+                            ),
+                          ],
+                        ),
+                        onPressed: () {
+                          Routes.pop(context);
+                        }),
+                  ),
+                ),
+                Flexible(
+                  fit: FlexFit.loose,
+                  child: Padding(
+                    padding: const EdgeInsets.only(left: 5),
+                    child: RaisedButton(
+                        key: const Key('ConfirmDialogConfirmButton'),
+                        shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(10.0),
+                            side: const BorderSide(
+                                color: Color.fromRGBO(0, 0, 0, 0.3))),
+                        color: const Color.fromRGBO(255, 157, 0, 1),
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: <Widget>[
+                            confirmButtonIcon,
+                            Flexible(
+                              fit: FlexFit.tight,
+                              child: Text(
+                                confirmButtonText,
+                                style: const TextStyle(color: Colors.white),
+                              ),
+                            ),
+                          ],
+                        ),
+                        onPressed: () {
+                          confirmOnPressed();
+                        }),
+                  ),
+                ),
               ],
             ),
           )

--- a/test/widgets/giraf_confirm_dialog_test.dart
+++ b/test/widgets/giraf_confirm_dialog_test.dart
@@ -29,8 +29,7 @@ class MockScreen extends StatelessWidget {
               title: 'test',
               description: 'test',
               confirmButtonText: 'test',
-              confirmButtonIcon:
-                  const ImageIcon(AssetImage('assets/icons/logout.png')),
+              confirmButtonIcon: const ImageIcon(null),
               confirmOnPressed: () {
                 Routes.pop(context);
               });

--- a/test/widgets/giraf_confirm_dialog_test.dart
+++ b/test/widgets/giraf_confirm_dialog_test.dart
@@ -40,17 +40,30 @@ class MockScreen extends StatelessWidget {
 void main() {
   testWidgets('Test if Confirm Dialog is shown', (WidgetTester tester) async {
     await tester.pumpWidget(MaterialApp(home: MockScreen()));
-    await tester.pump();
     await tester.tap(find.byKey(const Key('FirstButton')));
-    await tester.pumpAndSettle();
+    await tester.pump();
     expect(find.byType(GirafConfirmDialog), findsOneWidget);
   });
 
-  /*testWidgets('Test if Confirm Dialog is closed again', (WidgetTester tester) {
-    tester.pumpWidget(MaterialApp(home: MockScreen()));
-    tester.tap(find.byKey(const Key('FirstButton')));
-    expect(find.byType(CircularProgressIndicator), findsOneWidget);
-    tester.tap(find.byKey(const Key('SecondButton')));
-    expect(find.byType(CircularProgressIndicator), findsNothing);
-  });*/
+  testWidgets('Test if Confirm Dialog is closed when tapping Cancel button',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(home: MockScreen()));
+    await tester.tap(find.byKey(const Key('FirstButton')));
+    await tester.pump();
+    await tester.tap(find.byKey(const Key('ConfirmDialogCancelButton')));
+    await tester.pump();
+    expect(find.byType(GirafConfirmDialog), findsNothing);
+  });
+
+  //In this case, the confirmed action is closing the widget
+  testWidgets(
+      'Test if confirmed action is performed when tapping Confirm button',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(home: MockScreen()));
+    await tester.tap(find.byKey(const Key('FirstButton')));
+    await tester.pump();
+    await tester.tap(find.byKey(const Key('ConfirmDialogConfirmButton')));
+    await tester.pump();
+    expect(find.byType(GirafConfirmDialog), findsNothing);
+  });
 }

--- a/test/widgets/giraf_confirm_dialog_test.dart
+++ b/test/widgets/giraf_confirm_dialog_test.dart
@@ -50,6 +50,7 @@ void main() {
     await tester.pumpWidget(MaterialApp(home: MockScreen()));
     await tester.tap(find.byKey(const Key('FirstButton')));
     await tester.pump();
+    expect(find.byType(GirafConfirmDialog), findsOneWidget);
     await tester.tap(find.byKey(const Key('ConfirmDialogCancelButton')));
     await tester.pump();
     expect(find.byType(GirafConfirmDialog), findsNothing);
@@ -62,6 +63,7 @@ void main() {
     await tester.pumpWidget(MaterialApp(home: MockScreen()));
     await tester.tap(find.byKey(const Key('FirstButton')));
     await tester.pump();
+    expect(find.byType(GirafConfirmDialog), findsOneWidget);
     await tester.tap(find.byKey(const Key('ConfirmDialogConfirmButton')));
     await tester.pump();
     expect(find.byType(GirafConfirmDialog), findsNothing);

--- a/test/widgets/giraf_confirm_dialog_test.dart
+++ b/test/widgets/giraf_confirm_dialog_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:weekplanner/routes.dart';
+import 'package:weekplanner/widgets/giraf_confirm_dialog.dart';
+
+class MockScreen extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Container(
+          child: Column(
+        children: <Widget>[
+          RaisedButton(
+              key: const Key('FirstButton'),
+              onPressed: () {
+                confirmDialog(context);
+              }),
+        ],
+      )),
+    );
+  }
+
+  void confirmDialog(BuildContext context) {
+    showDialog<Center>(
+        barrierDismissible: false,
+        context: context,
+        builder: (BuildContext context) {
+          return GirafConfirmDialog(
+              title: 'test',
+              description: 'test',
+              confirmButtonText: 'test',
+              confirmButtonIcon:
+                  const ImageIcon(AssetImage('assets/icons/logout.png')),
+              confirmOnPressed: () {
+                Routes.pop(context);
+              });
+        });
+  }
+}
+
+void main() {
+  testWidgets('Test if Confirm Dialog is shown', (WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(home: MockScreen()));
+    await tester.pump();
+    await tester.tap(find.byKey(const Key('FirstButton')));
+    await tester.pumpAndSettle();
+    expect(find.byType(GirafConfirmDialog), findsOneWidget);
+  });
+
+  /*testWidgets('Test if Confirm Dialog is closed again', (WidgetTester tester) {
+    tester.pumpWidget(MaterialApp(home: MockScreen()));
+    tester.tap(find.byKey(const Key('FirstButton')));
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    tester.tap(find.byKey(const Key('SecondButton')));
+    expect(find.byType(CircularProgressIndicator), findsNothing);
+  });*/
+}


### PR DESCRIPTION
This closes #158 .
Generic dialog widget for confirming an action.

Buttons should be adjusted to the result of issue #85 
![ConfirmDialog](https://user-images.githubusercontent.com/22813275/56573322-1fe97d80-65c1-11e9-8dec-a9e9e947fb2a.png)

