### PR TITLE
feature #108 Missing tests for issue 88.

### DIFF
--- a/test/widgets/giraf_notify_dialog_test.dart
+++ b/test/widgets/giraf_notify_dialog_test.dart
@@ -44,6 +44,7 @@ void main() {
         await tester.pumpWidget(MaterialApp(home: MockScreen()));
         await tester.tap(find.byKey(const Key('FirstButton')));
         await tester.pump();
+        expect(find.byKey(const Key('NotifyDialogOkayButton')), findsOneWidget);
         await tester.tap(find.byKey(const Key('NotifyDialogOkayButton')));
         await tester.pump();
         expect(find.byType(GirafNotifyDialog), findsNothing);

--- a/test/widgets/giraf_notify_dialog_test.dart
+++ b/test/widgets/giraf_notify_dialog_test.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:weekplanner/widgets/giraf_notify_dialog.dart';
+
+class MockScreen extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Container(
+          child: Column(
+            children: <Widget>[
+              RaisedButton(
+                  key: const Key('FirstButton'),
+                  onPressed: () {
+                    notifyDialog(context);
+                  }),
+            ],
+          )),
+    );
+  }
+
+  void notifyDialog(BuildContext context) {
+    showDialog<Center>(
+        barrierDismissible: false,
+        context: context,
+        builder: (BuildContext context) {
+          return const GirafNotifyDialog(
+              title: 'testTitle',
+              description: 'testDescription');
+        });
+  }
+}
+
+void main() {
+  testWidgets('Test if Notify Dialog is shown', (WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(home: MockScreen()));
+    await tester.tap(find.byKey(const Key('FirstButton')));
+    await tester.pump();
+    expect(find.byType(GirafNotifyDialog), findsOneWidget);
+  });
+
+  testWidgets('Test if Notify Dialog is closed when tapping Okay button',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(MaterialApp(home: MockScreen()));
+        await tester.tap(find.byKey(const Key('FirstButton')));
+        await tester.pump();
+        await tester.tap(find.byKey(const Key('NotifyDialogOkayButton')));
+        await tester.pump();
+        expect(find.byType(GirafNotifyDialog), findsNothing);
+      });
+
+}


### PR DESCRIPTION
This closes #108.
Issue #108 was opened because there was missing tests on closed issue #88.
Tests for #88 have been made, which test that the Notify Dialog opens and closes.
