### PR TITLE
Feature 166 Logout uses GirafConfirmDialog

### DIFF
--- a/lib/blocs/toolbar_bloc.dart
+++ b/lib/blocs/toolbar_bloc.dart
@@ -7,6 +7,7 @@ import 'package:weekplanner/blocs/auth_bloc.dart';
 import 'package:weekplanner/di.dart';
 import 'package:weekplanner/routes.dart';
 import 'package:weekplanner/screens/settings_screen.dart';
+import 'package:weekplanner/widgets/giraf_confirm_dialog.dart';
 
 /// Contains the functionality of the toolbar.
 class ToolbarBloc extends BlocBase {
@@ -270,37 +271,19 @@ class ToolbarBloc extends BlocBase {
       icon: Image.asset('assets/icons/logout.png'),
       tooltip: 'Log ud',
       onPressed: () {
-        Alert(
-          context: context,
-          type: AlertType.none,
-          style: _alertStyle,
-          title: 'Log ud',
-          desc: 'Vil du logge ud?',
-          buttons: <DialogButton>[
-            DialogButton(
-              child: const Text(
-                'Fortryd',
-                style: TextStyle(color: Colors.black, fontSize: 20),
-              ),
-              onPressed: () {
-                Navigator.pop(context);
-              },
-              color: const Color.fromRGBO(255, 157, 0, 100),
-              width: 120,
-            ),
-            DialogButton(
-              child: const Text(
-                'Log ud',
-                style: TextStyle(color: Colors.black, fontSize: 20),
-              ),
-              onPressed: () {
-                _authBloc.logout();
-              },
-              color: const Color.fromRGBO(255, 157, 0, 100),
-              width: 120,
-            ),
-          ],
-        ).show();
+        showDialog<Center>(
+            barrierDismissible: false,
+            context: context,
+            builder: (BuildContext context) {
+              return GirafConfirmDialog(
+                title: 'Log ud',
+                description: 'Vil du logge ud?',
+                confirmButtonText: 'Log ud',
+                confirmButtonIcon:
+                    const ImageIcon(AssetImage('assets/icons/logout.png')),
+                confirmOnPressed: () => _authBloc.logout(),
+              );
+            });
       },
     );
   }
@@ -355,7 +338,7 @@ class ToolbarBloc extends BlocBase {
     );
   }
 
-  /// Password controller for passing information from a text field 
+  /// Password controller for passing information from a text field
   /// to the authenticator.
   final TextEditingController passwordCtrl = TextEditingController();
 

--- a/test/screens/login_screen_test.dart
+++ b/test/screens/login_screen_test.dart
@@ -199,8 +199,9 @@ void main() {
     bloc.loggedIn.listen((bool success) async {
       await tester.pump();
       expect(success, true);
-      await done.future;
+      done.complete();
     });
+    await done.future;
   });
 
   testWidgets(

--- a/test/widgets/giraf_app_bar_widget_test.dart
+++ b/test/widgets/giraf_app_bar_widget_test.dart
@@ -55,7 +55,6 @@ const String keyOfVisibilityForEdit = 'visibilityEditBtn';
 
 void main() {
   ToolbarBloc bloc;
-  Api api;
   MockAuth authBloc;
 
   setUp(() {
@@ -329,7 +328,8 @@ void main() {
         await tester.pumpAndSettle();
         expect(find.byType(GirafConfirmDialog), findsOneWidget);
         await tester.pump();
-        expect(find.byKey(const Key('ConfirmDialogConfirmButton')), findsOneWidget);
+        expect(find.byKey(const Key('ConfirmDialogConfirmButton')),
+            findsOneWidget);
         await tester.pump();
         await tester.tap(find.byKey(const Key('ConfirmDialogConfirmButton')));
         authBloc.loggedIn.listen((bool statusLogout) async {

--- a/test/widgets/giraf_app_bar_widget_test.dart
+++ b/test/widgets/giraf_app_bar_widget_test.dart
@@ -8,7 +8,6 @@ import 'package:weekplanner/blocs/auth_bloc.dart';
 import 'package:weekplanner/blocs/toolbar_bloc.dart';
 import 'package:weekplanner/di.dart';
 import 'package:weekplanner/models/enums/app_bar_icons_enum.dart';
-import 'package:api_client/api/api.dart';
 import 'package:weekplanner/widgets/giraf_app_bar_widget.dart';
 import 'package:mockito/mockito.dart';
 import 'package:weekplanner/widgets/giraf_confirm_dialog.dart';
@@ -58,7 +57,6 @@ void main() {
   MockAuth authBloc;
 
   setUp(() {
-    api = Api('any');
     di.clearAll();
     authBloc = MockAuth();
     di.registerDependency<AuthBloc>((_) => authBloc);

--- a/test/widgets/giraf_app_bar_widget_test.dart
+++ b/test/widgets/giraf_app_bar_widget_test.dart
@@ -325,10 +325,8 @@ void main() {
         await tester.tap(find.byTooltip('Log ud'));
         await tester.pumpAndSettle();
         expect(find.byType(GirafConfirmDialog), findsOneWidget);
-        await tester.pump();
         expect(find.byKey(const Key('ConfirmDialogConfirmButton')),
             findsOneWidget);
-        await tester.pump();
         await tester.tap(find.byKey(const Key('ConfirmDialogConfirmButton')));
         authBloc.loggedIn.listen((bool statusLogout) async {
           if (statusLogout == false) {

--- a/test/widgets/giraf_app_bar_widget_test.dart
+++ b/test/widgets/giraf_app_bar_widget_test.dart
@@ -1,6 +1,9 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:rxdart/rxdart.dart';
 import 'package:weekplanner/blocs/auth_bloc.dart';
 import 'package:weekplanner/blocs/toolbar_bloc.dart';
 import 'package:weekplanner/di.dart';
@@ -8,8 +11,44 @@ import 'package:weekplanner/models/enums/app_bar_icons_enum.dart';
 import 'package:api_client/api/api.dart';
 import 'package:weekplanner/widgets/giraf_app_bar_widget.dart';
 import 'package:mockito/mockito.dart';
+import 'package:weekplanner/widgets/giraf_confirm_dialog.dart';
 
-class MockAuth extends Mock implements AuthBloc {}
+class MockAuth extends Mock implements AuthBloc {
+  @override
+  Observable<bool> get loggedIn => _loggedIn.stream;
+  final BehaviorSubject<bool> _loggedIn = BehaviorSubject<bool>.seeded(true);
+
+  @override
+  String loggedInUsername = 'Graatand';
+
+  @override
+  void authenticate(String username, String password) {
+    // Mock the API and allow these 2 users to ?login?
+    final bool status = (username == 'test' && password == 'test') ||
+        (username == 'Graatand' && password == 'password');
+    // If there is a successful login, remove the loading spinner,
+    // and push the status to the stream
+    if (status) {
+      loggedInUsername = username;
+    }
+    _loggedIn.add(status);
+  }
+
+  @override
+  void logout() {
+    _loggedIn.add(false);
+  }
+}
+
+class MockScreen extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+        appBar: GirafAppBar(
+            title: 'TestTitle',
+            appBarIcons: const <AppBarIcon>[AppBarIcon.logout]));
+  }
+}
 
 /// Used to retrieve the visibility widget wrapping the editbutton
 const String keyOfVisibilityForEdit = 'visibilityEditBtn';
@@ -17,12 +56,13 @@ const String keyOfVisibilityForEdit = 'visibilityEditBtn';
 void main() {
   ToolbarBloc bloc;
   Api api;
+  MockAuth authBloc;
 
   setUp(() {
     api = Api('any');
-
     di.clearAll();
-    di.registerDependency<AuthBloc>((_) => AuthBloc(api));
+    authBloc = MockAuth();
+    di.registerDependency<AuthBloc>((_) => authBloc);
     bloc = ToolbarBloc();
     di.registerDependency<ToolbarBloc>((_) => bloc);
   });
@@ -268,4 +308,36 @@ void main() {
 
     expect(find.byTooltip('Fortryd'), findsOneWidget);
   });
+
+  testWidgets('GirafConfirmDialog is shown on logout icon press',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(MaterialApp(home: MockScreen()));
+        await tester.pump();
+        expect(find.byTooltip('Log ud'), findsOneWidget);
+        await tester.tap(find.byTooltip('Log ud'));
+        await tester.pump();
+        expect(find.byType(GirafConfirmDialog), findsOneWidget);
+      });
+
+  testWidgets('User is logged out on confirmation in GirafConfirmDialog',
+          (WidgetTester tester) async {
+        final Completer<bool> done = Completer<bool>();
+        await tester.pumpWidget(MaterialApp(home: MockScreen()));
+        await tester.pump();
+        expect(find.byTooltip('Log ud'), findsOneWidget);
+        await tester.tap(find.byTooltip('Log ud'));
+        await tester.pumpAndSettle();
+        expect(find.byType(GirafConfirmDialog), findsOneWidget);
+        await tester.pump();
+        expect(find.byKey(const Key('ConfirmDialogConfirmButton')), findsOneWidget);
+        await tester.pump();
+        await tester.tap(find.byKey(const Key('ConfirmDialogConfirmButton')));
+        authBloc.loggedIn.listen((bool statusLogout) async {
+          if (statusLogout == false) {
+            expect(statusLogout, isFalse);
+            done.complete();
+          }
+        });
+        await done.future;
+      });
 }


### PR DESCRIPTION
This closes #166.

GirafConfirmDialog replaced the alert message for logout, so the logout dialog follows the design guide. 
Tests have been made for the ToolbarBloc, and test that the GirafConfirmDialog is shown, when the logout icon is pressed in the appbar, and that the user is logged out on confirmation in the dialog.

Changes in the login_screen_test was requested by the creator of the test(A fellow group member).

![image](https://user-images.githubusercontent.com/26058779/56715338-af18a180-6737-11e9-9955-c2910e42a1f6.png)
