### PR TITLE
Releasefix #186

### DIFF
--- a/lib/blocs/new_weekplan_bloc.dart
+++ b/lib/blocs/new_weekplan_bloc.dart
@@ -134,7 +134,7 @@ class NewWeekplanBloc extends BlocBase {
     if (input == null) {
       sink.add(null);
     } else {
-      sink.add(input.isNotEmpty);
+      sink.add(input.trim().isNotEmpty);
     }
   });
 

--- a/lib/screens/new_weekplan_screen.dart
+++ b/lib/screens/new_weekplan_screen.dart
@@ -2,6 +2,7 @@ import 'package:api_client/models/pictogram_model.dart';
 import 'package:api_client/models/username_model.dart';
 import 'package:api_client/models/week_model.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:weekplanner/blocs/new_weekplan_bloc.dart';
 import 'package:weekplanner/di.dart';
 import 'package:weekplanner/routes.dart';
@@ -35,6 +36,12 @@ class NewWeekplanScreen extends StatelessWidget {
                       (BuildContext context, AsyncSnapshot<bool> snapshot) {
                     return TextField(
                       onChanged: _bloc.onTitleChanged.add,
+                      keyboardType: TextInputType.text,
+                      // To avoid emojis and other special characters
+                      inputFormatters: [
+                        WhitelistingTextInputFormatter(
+                            RegExp('[a-zA-Z0-9æøåÆØÅ,._#\'()\-]'))
+                      ],
                       style: _style,
                       decoration: InputDecoration(
                           labelText: 'Titel',

--- a/lib/screens/new_weekplan_screen.dart
+++ b/lib/screens/new_weekplan_screen.dart
@@ -35,10 +35,11 @@ class NewWeekplanScreen extends StatelessWidget {
                   builder:
                       (BuildContext context, AsyncSnapshot<bool> snapshot) {
                     return TextField(
+                      key: const Key('NewWeekplanTitleField'),
                       onChanged: _bloc.onTitleChanged.add,
                       keyboardType: TextInputType.text,
                       // To avoid emojis and other special characters
-                      inputFormatters: [
+                      inputFormatters: <TextInputFormatter>[
                         WhitelistingTextInputFormatter(
                             RegExp('[a-zA-Z0-9æøåÆØÅ,._#\'()\-]'))
                       ],

--- a/lib/screens/new_weekplan_screen.dart
+++ b/lib/screens/new_weekplan_screen.dart
@@ -41,7 +41,7 @@ class NewWeekplanScreen extends StatelessWidget {
                       // To avoid emojis and other special characters
                       inputFormatters: <TextInputFormatter>[
                         WhitelistingTextInputFormatter(
-                            RegExp('[a-zA-Z0-9æøåÆØÅ,._#\'()\-]'))
+                            RegExp('[ -~\u00C0-\u00FF]'))
                       ],
                       style: _style,
                       decoration: InputDecoration(

--- a/lib/screens/weekplan_selector_screen.dart
+++ b/lib/screens/weekplan_selector_screen.dart
@@ -118,8 +118,10 @@ class WeekplanSelectorScreen extends StatelessWidget {
                   return AutoSizeText(
                     weekplan.name,
                     style: const TextStyle(fontSize: 18),
-                    maxLines: 2,
+                    maxLines: 1,
+                    minFontSize: 14,
                     textAlign: TextAlign.center,
+                    overflow: TextOverflow.ellipsis,
                   );
                 }))
               ],

--- a/test/blocs/new_weekplan_bloc_test.dart
+++ b/test/blocs/new_weekplan_bloc_test.dart
@@ -60,6 +60,15 @@ void main() {
     });
   }));
 
+  test('Should not validate title: [space]', async((DoneFn done) {
+    bloc.onTitleChanged.add(' ');
+    bloc.validTitleStream.listen((bool isValid) {
+      expect(isValid, isNotNull);
+      expect(isValid, false);
+      done();
+    });
+  }));
+
   test('Should not validate title: [empty string]', async((DoneFn done) {
     bloc.onTitleChanged.add('');
     bloc.validTitleStream.listen((bool isValid) {
@@ -79,8 +88,7 @@ void main() {
     });
   }));
 
-  test('Should validate year: 1990',
-      async((DoneFn done) {
+  test('Should validate year: 1990', async((DoneFn done) {
     bloc.onYearChanged.add('1990');
     bloc.validYearStream.listen((bool isValid) {
       expect(isValid, isNotNull);
@@ -89,8 +97,7 @@ void main() {
     });
   }));
 
-  test('Should not validate year: 1',
-      async((DoneFn done) {
+  test('Should not validate year: 1', async((DoneFn done) {
     bloc.onYearChanged.add('1');
     bloc.validYearStream.listen((bool isValid) {
       expect(isValid, isNotNull);

--- a/test/screens/new_weekplan_screen_test.dart
+++ b/test/screens/new_weekplan_screen_test.dart
@@ -152,9 +152,7 @@ void main() {
     await tester.pumpWidget(MaterialApp(home: NewWeekplanScreen(mockUser)));
     await tester.pump();
 
-    expect(
-        find.text('År skal angives som fire cifre'),
-        findsOneWidget);
+    expect(find.text('År skal angives som fire cifre'), findsOneWidget);
   });
 
   testWidgets('No error text is shown on valid year input',
@@ -163,9 +161,7 @@ void main() {
     await tester.pumpWidget(MaterialApp(home: NewWeekplanScreen(mockUser)));
     await tester.pump();
 
-    expect(
-        find.text('År skal angives som fire cifre'),
-        findsNothing);
+    expect(find.text('År skal angives som fire cifre'), findsNothing);
   });
 
   testWidgets('Error text is shown on invalid week number input',
@@ -184,6 +180,16 @@ void main() {
     await tester.pump();
 
     expect(find.text('Ugenummer skal være mellem 1 og 53'), findsNothing);
+  });
+
+  testWidgets('Emojis are blacklisted from title field',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(home: NewWeekplanScreen(mockUser)));
+    await tester.enterText(
+        find.byKey(const Key('NewWeekplanTitleField')), '☺♥');
+    await tester.pump();
+
+    expect(find.text('☺♥'), findsNothing);
   });
 
   testWidgets('Click on thumbnail redirects to pictogram search screen',


### PR DESCRIPTION
This closes #186. 
Emojis can no longer be entered in the title field. This is done by Regex whitelisting. If anyone has a better way to do this, please let us know.

The weekplan_selector_screen now renders overflow titles in the following way:
![image](https://user-images.githubusercontent.com/26706644/56797404-e9a43c00-6814-11e9-906a-e99025dcfc66.png)
