### PR TITLE
Azure pipelines changes

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,7 +22,7 @@ jobs:
           projectDirectory: $(projectDirectory)
       - task: CopyFiles@2
         inputs:
-          contents: '$(projectDirectory)/build/app/outputs/apk/**/*.apk'
+          contents: '**/*.apk'
           targetFolder: '$(build.artifactStagingDirectory)'
       - task: PublishBuildArtifacts@1
         inputs:
@@ -57,4 +57,4 @@ jobs:
       - task: PublishBuildArtifacts@1
         inputs:
           pathtoPublish: $(build.artifactStagingDirectory)
-          artifactName: iOS
+          artifactName: iOS (iPhone, iPad)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,7 +22,7 @@ jobs:
           projectDirectory: $(projectDirectory)
       - task: CopyFiles@2
         inputs:
-          contents: '**/*.apk'
+          contents: '$(projectDirectory)/build/app/outputs/apk/release/*.apk'
           targetFolder: '$(build.artifactStagingDirectory)'
       - task: PublishBuildArtifacts@1
         inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,7 +20,6 @@ jobs:
         inputs:
           projectDirectory: $(projectDirectory)
       - task: CopyFiles@2
-          displayName: 'Copy Files to: $(Build.ArtifactStagingDirectory)'
           inputs:
             contents: '**/(*.apk|*.app)'
             targetFolder: '$(build.artifactStagingDirectory)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,14 +50,14 @@ jobs:
           projectDirectory: $(projectDirectory)
       - task: ArchiveFiles@2
         inputs:
-          ootFolderOrFile: '$(projectDirectory)/build/ios/Runner.app/'
-          #includeRootFolder: true
+          ootFolderOrFile: $(agent.buildDirectory)
+          includeRootFolder: true
           rchiveType: 'zip'
       - task: CopyFiles@2
         inputs:
-          contents: '$(projectDirectory)/build/ios/*.zip'
+          contents: '**/*.zip'
           targetFolder: '$(build.artifactStagingDirectory)'
       - task: PublishBuildArtifacts@1
         inputs:
-          pathtoPublish: '$(build.artifactStagingDirectory)'
+          pathtoPublish: $(build.artifactStagingDirectory)
           artifactName: iOS

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,13 +50,10 @@ jobs:
           projectDirectory: $(projectDirectory)
       - task: ArchiveFiles@2
         inputs:
-          ootFolderOrFile: $(agent.buildDirectory)
+          rootFolderOrFile: '$(Build.BinariesDirectory)'
           includeRootFolder: true
           rchiveType: 'zip'
-      - task: CopyFiles@2
-        inputs:
-          contents: '**/*.zip'
-          targetFolder: '$(build.artifactStagingDirectory)'
+          archiveFile: '$(Build.ArtifactStagingDirectory)/ios_app.zip'
       - task: PublishBuildArtifacts@1
         inputs:
           pathtoPublish: $(build.artifactStagingDirectory)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,9 +46,6 @@ jobs:
         inputs:
           target: ios
           projectDirectory: $(projectDirectory)
-      - task: FlutterTest@0
-        inputs:
-          projectDirectory: $(projectDirectory)
       - task: CopyFiles@2
         inputs:
           contents: '**/$(BuildConfiguration)/**'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,11 +20,10 @@ jobs:
         inputs:
           projectDirectory: $(projectDirectory)
       - task: CopyFiles@2
-        inputs:
-          contents: '**/*.apk'
-          targetFolder: '$(build.artifactStagingDirectory)'
-      - task: CopyFiles@2
+          displayName: 'Copy Files to: $(Build.ArtifactStagingDirectory)'
           inputs:
-            contents: '**/*.app'
+            contents: |
+              **/*.app
+              **/*.apk
             targetFolder: '$(build.artifactStagingDirectory)'
       - task: PublishBuildArtifacts@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,7 +16,7 @@ jobs:
         inputs:
           target: apk
           projectDirectory: $(projectDirectory)
-      - task: FlutterBuild@1
+      - task: FlutterBuild@0
           inputs:
             target: ios
             projectDirectory: $(projectDirectory)
@@ -27,7 +27,7 @@ jobs:
         inputs:
           contents: '**/*.apk'
           targetFolder: '$(build.artifactStagingDirectory)'
-      - task: CopyFiles@3
+      - task: CopyFiles@2
           inputs:
             contents: '**/*.app'
             targetFolder: '$(build.artifactStagingDirectory)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,6 +48,6 @@ jobs:
           projectDirectory: $(projectDirectory)
       - task: CopyFiles@2
         inputs:
-          contents: '**/*.app'
+          contents: '$(projectDirectory)/build/ios/**/*.app'
           targetFolder: '$(build.artifactStagingDirectory)'
       - task: PublishBuildArtifacts@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,7 +20,7 @@ jobs:
         inputs:
           projectDirectory: $(projectDirectory)
       - task: CopyFiles@2
-          inputs:
-            contents: '**/?(*.apk|*.app)'
-            targetFolder: '$(build.artifactStagingDirectory)'
+        inputs:
+          contents: '**/?(*.apk|*.app)'
+          targetFolder: '$(build.artifactStagingDirectory)'
       - task: PublishBuildArtifacts@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,9 +48,9 @@ jobs:
           projectDirectory: $(projectDirectory)
       - task: CopyFiles@2
         inputs:
-          contents: '**/$(BuildConfiguration)/**'
+          contents: '/Users/vsts/agent/2.150.0/work/1/s/build/ios/iphoneos/Runner.app'
           targetFolder: '$(build.artifactStagingDirectory)'
       - task: PublishBuildArtifacts@1
         inputs:
-          pathtoPublish: '$(Build.ArtifactStagingDirectory)'
+          pathtoPublish: '$(projectDirectory)'
           artifactName: drop2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,13 +14,34 @@ jobs:
           script: $(FlutterToolPath)/flutter analyze
       - task: FlutterBuild@0
         inputs:
-          target: All
+          target: apk
           projectDirectory: $(projectDirectory)
       - task: FlutterTest@0
         inputs:
           projectDirectory: $(projectDirectory)
       - task: CopyFiles@2
         inputs:
-          contents: '**/?(*.apk|*.app)'
+          contents: '**/*.apk'
           targetFolder: '$(build.artifactStagingDirectory)'
       - task: PublishBuildArtifacts@1
+  - job: iOS
+      pool:
+        vmImage: 'macOS-10.13'
+      steps:
+        - task: FlutterInstall@0
+        - task: Bash@3
+          inputs:
+            targetType: inline
+            script: $(FlutterToolPath)/flutter analyze
+        - task: FlutterBuild@0
+          inputs:
+            target: iOS
+            projectDirectory: $(projectDirectory)
+        - task: FlutterTest@0
+          inputs:
+            projectDirectory: $(projectDirectory)
+        - task: CopyFiles@2
+          inputs:
+            contents: '**/*.app'
+            targetFolder: '$(build.artifactStagingDirectory)'
+        - task: PublishBuildArtifacts@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,7 +30,11 @@ jobs:
       - task: InstallAppleCertificate@2
         inputs:
           certSecureFile: 'cert.p12'
-      - task: FlutterInstall@0
+      - task: InstallAppleProvisioningProfile@1
+        inputs:
+          provProfileSecureFile: '82a27128-6283-49f0-90a3-2440591810d1.mobileprovision'
+
+          - task: FlutterInstall@0
       - task: Bash@3
         inputs:
           targetType: inline

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,9 +28,12 @@ jobs:
     pool:
       vmImage: 'macOS-10.13'
     steps:
+      - task: DownloadSecureFile@1
+        inputs:
+          secureFile: 'cert.p12'
       - task: InstallAppleCertificate@2
         inputs:
-          certSecureFile: 'cert.p12'
+          certSecureFile: $env:DOWNLOADSECUREFILE_SECUREFILEPATH
       - task: FlutterInstall@0
       - task: Bash@3
         inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,6 +24,9 @@ jobs:
           contents: '**/*.apk'
           targetFolder: '$(build.artifactStagingDirectory)'
       - task: PublishBuildArtifacts@1
+        inputs:
+          pathtoPublish: '$(Build.ArtifactStagingDirectory)'
+          artifactName: drop1
   - job: iOS
     pool:
       vmImage: 'macOS-10.13'
@@ -48,6 +51,9 @@ jobs:
           projectDirectory: $(projectDirectory)
       - task: CopyFiles@2
         inputs:
-          contents: '$(projectDirectory)/build/ios/**/*.app'
+          contents: '**/*.ipa'
           targetFolder: '$(build.artifactStagingDirectory)'
       - task: PublishBuildArtifacts@1
+        inputs:
+          pathtoPublish: '$(Build.ArtifactStagingDirectory)'
+          artifactName: drop2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,6 +21,6 @@ jobs:
           projectDirectory: $(projectDirectory)
       - task: CopyFiles@2
           inputs:
-            contents: '**/(*.apk|*.app)'
+            contents: '**/*\.(apk|app)'
             targetFolder: '$(build.artifactStagingDirectory)'
       - task: PublishBuildArtifacts@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,7 +51,7 @@ jobs:
       - task: ArchiveFiles@2
         inputs:
           ootFolderOrFile: '$(projectDirectory)/build/ios/Runner.app/'
-          includeRootFolder: true
+          #includeRootFolder: true
           rchiveType: 'zip'
       - task: CopyFiles@2
         inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,33 +28,33 @@ jobs:
         inputs:
           pathtoPublish: '$(Build.ArtifactStagingDirectory)'
           artifactName: Android
-  - job: iOS
-    pool:
-      vmImage: 'macOS-10.13'
-    steps:
-      - task: InstallAppleCertificate@2
-        inputs:
-          certSecureFile: 'cert.p12'
-      - task: InstallAppleProvisioningProfile@1
-        inputs:
-          provProfileSecureFile: '82a27128-6283-49f0-90a3-2440591810d1.mobileprovision'
-      - task: FlutterInstall@0
-      - task: Bash@3
-        displayName: 'Linter'
-        inputs:
-          targetType: inline
-          script: $(FlutterToolPath)/flutter analyze
-      - task: FlutterBuild@0
-        inputs:
-          target: ios
-          projectDirectory: $(projectDirectory)
-      - task: ArchiveFiles@2
-        inputs:
-          rootFolderOrFile: '$(projectDirectory)/build/ios/iphoneos/Runner.app'
-          includeRootFolder: true
-          rchiveType: 'zip'
-          archiveFile: '$(Build.ArtifactStagingDirectory)/ios_app.zip'
-      - task: PublishBuildArtifacts@1
-        inputs:
-          pathtoPublish: $(build.artifactStagingDirectory)
-          artifactName: iOS (iPhone, iPad)
+  #- job: iOS
+  #  pool:
+  #    vmImage: 'macOS-10.13'
+  #  steps:
+  #    - task: InstallAppleCertificate@2
+  #      inputs:
+  #        certSecureFile: 'cert.p12'
+  #    - task: InstallAppleProvisioningProfile@1
+  #      inputs:
+  #        provProfileSecureFile: '82a27128-6283-49f0-90a3-2440591810d1.mobileprovision'
+  #    - task: FlutterInstall@0
+  #    - task: Bash@3
+  #      displayName: 'Linter'
+  #      inputs:
+  #        targetType: inline
+  #        script: $(FlutterToolPath)/flutter analyze
+  #    - task: FlutterBuild@0
+  #      inputs:
+  #        target: ios
+  #        projectDirectory: $(projectDirectory)
+  #    - task: ArchiveFiles@2
+  #      inputs:
+  #        rootFolderOrFile: '$(projectDirectory)/build/ios/iphoneos/Runner.app'
+  #        includeRootFolder: true
+  #        rchiveType: 'zip'
+  #        archiveFile: '$(Build.ArtifactStagingDirectory)/ios_app.zip'
+  #    - task: PublishBuildArtifacts@1
+  #      inputs:
+  #        pathtoPublish: $(build.artifactStagingDirectory)
+  #        artifactName: iOS (iPhone, iPad)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,23 +25,23 @@ jobs:
           targetFolder: '$(build.artifactStagingDirectory)'
       - task: PublishBuildArtifacts@1
   - job: iOS
-      pool:
-        vmImage: 'macOS-10.13'
-      steps:
-        - task: FlutterInstall@0
-        - task: Bash@3
-          inputs:
-            targetType: inline
-            script: $(FlutterToolPath)/flutter analyze
-        - task: FlutterBuild@0
-          inputs:
-            target: iOS
-            projectDirectory: $(projectDirectory)
-        - task: FlutterTest@0
-          inputs:
-            projectDirectory: $(projectDirectory)
-        - task: CopyFiles@2
-          inputs:
-            contents: '**/*.app'
-            targetFolder: '$(build.artifactStagingDirectory)'
-        - task: PublishBuildArtifacts@1
+    pool:
+      vmImage: 'macOS-10.13'
+    steps:
+      - task: FlutterInstall@0
+      - task: Bash@3
+        inputs:
+          targetType: inline
+          script: $(FlutterToolPath)/flutter analyze
+      - task: FlutterBuild@0
+        inputs:
+          target: iOS
+          projectDirectory: $(projectDirectory)
+      - task: FlutterTest@0
+        inputs:
+          projectDirectory: $(projectDirectory)
+      - task: CopyFiles@2
+        inputs:
+          contents: '**/*.app'
+          targetFolder: '$(build.artifactStagingDirectory)'
+      - task: PublishBuildArtifacts@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,6 +16,10 @@ jobs:
         inputs:
           target: apk
           projectDirectory: $(projectDirectory)
+      - task: FlutterBuild@1
+          inputs:
+            target: ios
+            projectDirectory: $(projectDirectory)
       - task: FlutterTest@0
         inputs:
           projectDirectory: $(projectDirectory)
@@ -23,4 +27,8 @@ jobs:
         inputs:
           contents: '**/*.apk'
           targetFolder: '$(build.artifactStagingDirectory)'
+      - task: CopyFiles@3
+          inputs:
+            contents: '**/*.app'
+            targetFolder: '$(build.artifactStagingDirectory)'
       - task: PublishBuildArtifacts@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,6 +28,7 @@ jobs:
         inputs:
           pathtoPublish: '$(Build.ArtifactStagingDirectory)'
           artifactName: Android
+  # This is for compiling to iOS, it is done, but there is no valid developer license, so it is commented out
   #- job: iOS
   #  pool:
   #    vmImage: 'macOS-10.13'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,8 +33,7 @@ jobs:
       - task: InstallAppleProvisioningProfile@1
         inputs:
           provProfileSecureFile: '82a27128-6283-49f0-90a3-2440591810d1.mobileprovision'
-
-          - task: FlutterInstall@0
+      - task: FlutterInstall@0
       - task: Bash@3
         inputs:
           targetType: inline

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,7 +50,7 @@ jobs:
           projectDirectory: $(projectDirectory)
       - task: ArchiveFiles@2
         inputs:
-          rootFolderOrFile: '$(Build.BinariesDirectory)'
+          rootFolderOrFile: '$(projectDirectory)/build/ios/iphoneos/Runner.app'
           includeRootFolder: true
           rchiveType: 'zip'
           archiveFile: '$(Build.ArtifactStagingDirectory)/ios_app.zip'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,6 +27,7 @@ jobs:
   - job: iOS
     pool:
       vmImage: 'macOS-10.13'
+    steps:
       - task: InstallAppleCertificate@2
         inputs:
           certSecureFile: 'cert.p12'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,7 +22,7 @@ jobs:
           projectDirectory: $(projectDirectory)
       - task: CopyFiles@2
         inputs:
-          contents: '$(projectDirectory)/build/app/outputs/apk/release/*.apk'
+          contents: '$(projectDirectory)/build/app/outputs/apk/**/*.apk'
           targetFolder: '$(build.artifactStagingDirectory)'
       - task: PublishBuildArtifacts@1
         inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,6 +9,7 @@ jobs:
     steps:
       - task: FlutterInstall@0
       - task: Bash@3
+        displayName: 'Linter'
         inputs:
           targetType: inline
           script: $(FlutterToolPath)/flutter analyze
@@ -26,7 +27,7 @@ jobs:
       - task: PublishBuildArtifacts@1
         inputs:
           pathtoPublish: '$(Build.ArtifactStagingDirectory)'
-          artifactName: drop1
+          artifactName: Android
   - job: iOS
     pool:
       vmImage: 'macOS-10.13'
@@ -39,6 +40,7 @@ jobs:
           provProfileSecureFile: '82a27128-6283-49f0-90a3-2440591810d1.mobileprovision'
       - task: FlutterInstall@0
       - task: Bash@3
+        displayName: 'Linter'
         inputs:
           targetType: inline
           script: $(FlutterToolPath)/flutter analyze
@@ -46,11 +48,16 @@ jobs:
         inputs:
           target: ios
           projectDirectory: $(projectDirectory)
+      - task: ArchiveFiles@2
+        inputs:
+          ootFolderOrFile: '$(projectDirectory)/build/ios/Runner.app/'
+          includeRootFolder: true
+          rchiveType: 'zip'
       - task: CopyFiles@2
         inputs:
-          contents: '/Users/vsts/agent/2.150.0/work/1/s/build/ios/iphoneos/Runner.app'
+          contents: '$(projectDirectory)/build/ios/*.zip'
           targetFolder: '$(build.artifactStagingDirectory)'
       - task: PublishBuildArtifacts@1
         inputs:
-          pathtoPublish: '$(projectDirectory)'
-          artifactName: drop2
+          pathtoPublish: '$(build.artifactStagingDirectory)'
+          artifactName: iOS

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,6 +28,9 @@ jobs:
     pool:
       vmImage: 'macOS-10.13'
     steps:
+      - task: InstallAppleCertificate@2
+        inputs:
+          certSecureFile: 'cert.p12'
       - task: FlutterInstall@0
       - task: Bash@3
         inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,13 +27,9 @@ jobs:
   - job: iOS
     pool:
       vmImage: 'macOS-10.13'
-    steps:
-      - task: DownloadSecureFile@1
-        inputs:
-          secureFile: 'cert.p12'
       - task: InstallAppleCertificate@2
         inputs:
-          certSecureFile: '$(Agent.TempDirectory)/cert.p12'
+          certSecureFile: 'cert.p12'
       - task: FlutterInstall@0
       - task: Bash@3
         inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,12 +14,8 @@ jobs:
           script: $(FlutterToolPath)/flutter analyze
       - task: FlutterBuild@0
         inputs:
-          target: apk
+          target: All
           projectDirectory: $(projectDirectory)
-      - task: FlutterBuild@0
-          inputs:
-            target: ios
-            projectDirectory: $(projectDirectory)
       - task: FlutterTest@0
         inputs:
           projectDirectory: $(projectDirectory)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,7 +33,7 @@ jobs:
           secureFile: 'cert.p12'
       - task: InstallAppleCertificate@2
         inputs:
-          certSecureFile: $env:DOWNLOADSECUREFILE_SECUREFILEPATH
+          certSecureFile: '$(Agent.TempDirectory)/cert.p12'
       - task: FlutterInstall@0
       - task: Bash@3
         inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,7 +51,7 @@ jobs:
           projectDirectory: $(projectDirectory)
       - task: CopyFiles@2
         inputs:
-          contents: '**/*.ipa'
+          contents: '**/$(BuildConfiguration)/**'
           targetFolder: '$(build.artifactStagingDirectory)'
       - task: PublishBuildArtifacts@1
         inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,6 +21,6 @@ jobs:
           projectDirectory: $(projectDirectory)
       - task: CopyFiles@2
           inputs:
-            contents: '**/*\.(apk|app)'
+            contents: '**/?(*.apk|*.app)'
             targetFolder: '$(build.artifactStagingDirectory)'
       - task: PublishBuildArtifacts@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,8 +22,6 @@ jobs:
       - task: CopyFiles@2
           displayName: 'Copy Files to: $(Build.ArtifactStagingDirectory)'
           inputs:
-            contents: |
-              **/*.app
-              **/*.apk
+            contents: '**/(*.apk|*.app)'
             targetFolder: '$(build.artifactStagingDirectory)'
       - task: PublishBuildArtifacts@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,7 +35,7 @@ jobs:
           script: $(FlutterToolPath)/flutter analyze
       - task: FlutterBuild@0
         inputs:
-          target: iOS
+          target: ios
           projectDirectory: $(projectDirectory)
       - task: FlutterTest@0
         inputs:

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-# platform :ios, '9.0'
+platform :ios, '10.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -276,16 +276,12 @@
 			buildActionMask = 2147483647;
 			files = (
 			);
-			inputFileListPaths = (
-			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh",
 				"${PODS_ROOT}/../.symlinks/flutter/ios/Flutter.framework",
 				"${BUILT_PRODUCTS_DIR}/shared_preferences/shared_preferences.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-			);
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Flutter.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/shared_preferences.framework",

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>Weekplanner</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -31,6 +33,7 @@
 		<string>UIInterfaceOrientationPortrait</string>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 	</array>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>


### PR DESCRIPTION
Changed so linter is no longer called bash in Azure
Added iOS build, but is commented out until we get developer license.