### PR TITLE
release fix 185 Exception thrown by log out button

### DIFF
--- a/lib/blocs/auth_bloc.dart
+++ b/lib/blocs/auth_bloc.dart
@@ -1,6 +1,8 @@
 import 'package:api_client/api/api.dart';
+import 'package:flutter/material.dart';
 import 'package:rxdart/rxdart.dart';
 import 'package:weekplanner/blocs/bloc_base.dart';
+import 'package:weekplanner/routes.dart';
 
 /// All about Authentication. Login, logout, etc.
 class AuthBloc extends BlocBase {
@@ -35,10 +37,12 @@ class AuthBloc extends BlocBase {
   }
 
   /// Logs the currently logged in user out
-  void logout() {
+  void logout(BuildContext context) {
     _api.account.logout().take(1).listen((_) {
       _loggedIn.add(false);
     });
+
+    Routes.goHome(context);
   }
 
   @override

--- a/lib/blocs/toolbar_bloc.dart
+++ b/lib/blocs/toolbar_bloc.dart
@@ -281,7 +281,7 @@ class ToolbarBloc extends BlocBase {
                 confirmButtonText: 'Log ud',
                 confirmButtonIcon:
                     const ImageIcon(AssetImage('assets/icons/logout.png')),
-                confirmOnPressed: () => _authBloc.logout(),
+                confirmOnPressed: () => _authBloc.logout(context),
               );
             });
       },

--- a/lib/blocs/weekplan_bloc.dart
+++ b/lib/blocs/weekplan_bloc.dart
@@ -90,5 +90,6 @@ class WeekplanBloc extends BlocBase {
   @override
   void dispose() {
     _userWeek.close();
+    _activityPlaceholderVisible.close();
   }
 }

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -39,10 +39,6 @@ class LoginScreenState extends State<LoginScreen> {
     authBloc.authenticate(usernameCtrl.value.text, passwordCtrl.value.text);
     authBloc.loggedIn.listen((bool snapshot) {
       loginStatus = snapshot;
-      if (snapshot) {
-        // This is used instead of pop, because it fixes a login bug
-        Routes.goHome(currentContext);
-      }
     });
   }
 

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -39,6 +39,9 @@ class LoginScreenState extends State<LoginScreen> {
     authBloc.authenticate(usernameCtrl.value.text, passwordCtrl.value.text);
     authBloc.loggedIn.listen((bool snapshot) {
       loginStatus = snapshot;
+      if(snapshot){
+        Routes.pop(context);
+      }
     });
   }
 

--- a/test/widgets/giraf_app_bar_widget_test.dart
+++ b/test/widgets/giraf_app_bar_widget_test.dart
@@ -34,7 +34,7 @@ class MockAuth extends Mock implements AuthBloc {
   }
 
   @override
-  void logout() {
+  void logout(BuildContext context) {
     _loggedIn.add(false);
   }
 }


### PR DESCRIPTION
Fixed all the exceptions related to dirty states that where cause by the use of out dated BuildContext's

Log out now throws some other exceptions. But these are related to the API and we are unsure if it is caused by problems with the servers or by the weekplanner. 
But the exceptions related to our issue are fixed.

solves #185 