### PR TITLE
Feature 058

### DIFF
--- a/lib/blocs/activity_bloc.dart
+++ b/lib/blocs/activity_bloc.dart
@@ -9,13 +9,13 @@ import 'package:api_client/models/enums/activity_state_enum.dart';
 /// Logic for activities
 class ActivityBloc extends BlocBase {
   /// Default Constructor.
-  /// Initilizes values
+  /// Initializes values
   ActivityBloc(this._api);
 
   /// Stream for updated weekmodel.
   Stream<ActivityModel> get activityModelStream => _activityModelStream.stream;
 
-  /// BehaivorSubject for the updated weekmodel.
+  /// BehaviorSubject for the updated weekmodel.
   final BehaviorSubject<ActivityModel> _activityModelStream =
       BehaviorSubject<ActivityModel>();
 

--- a/lib/blocs/auth_bloc.dart
+++ b/lib/blocs/auth_bloc.dart
@@ -19,11 +19,11 @@ class AuthBloc extends BlocBase {
 
   /// Start with providing false as the logged in status
   final BehaviorSubject<bool> _loggedIn = BehaviorSubject<bool>.seeded(false);
-  /// Reflect the current clearence level of the user
+  /// Reflect the current clearance level of the user
   final BehaviorSubject<WeekplanMode> _mode =
   BehaviorSubject<WeekplanMode>.seeded(WeekplanMode.guardian);
 
-  /// The stream that emits the current clearence level
+  /// The stream that emits the current clearance level
   Observable<WeekplanMode> get mode => _mode.stream;
 
 
@@ -49,7 +49,7 @@ class AuthBloc extends BlocBase {
       _loggedIn.add(false);
     });
   }
-  /// Updates the mode of the weekpan
+  /// Updates the mode of the weekplan
   void setMode(WeekplanMode mode) {
     _mode.add(mode);
   }

--- a/lib/screens/show_activity_screen.dart
+++ b/lib/screens/show_activity_screen.dart
@@ -119,7 +119,8 @@ class ShowActivityScreen extends StatelessWidget {
     ];
   }
 
-  /// Builds the buttons below the activity widget.
+  /// Builds the button that changes the state of the activity. The content
+  /// of the button depends on whether it is in guardian or citizen mode.
   Widget buildButton() {
     return StreamBuilder<WeekplanMode>(
       stream: _authBloc.mode,
@@ -127,13 +128,38 @@ class ShowActivityScreen extends StatelessWidget {
           AsyncSnapshot<WeekplanMode> weekplanModeSnapshot) {
         return StreamBuilder<ActivityModel>(
             stream: _activityBloc.activityModelStream,
-            builder:
-                (BuildContext context, AsyncSnapshot<ActivityModel> snapshot) {
-              if (snapshot.data == null) {
+            builder: (BuildContext context,
+                AsyncSnapshot<ActivityModel> activitySnapshot) {
+              if (activitySnapshot.data == null) {
                 return const CircularProgressIndicator();
               }
-              return _buildChangeActivityStateButton(
-                  snapshot.data.state, weekplanModeSnapshot.data);
+              if (weekplanModeSnapshot.data == WeekplanMode.guardian) {
+                return GirafButton(
+                    key: const Key('CancelStateToggleButton'),
+                    onPressed: () {
+                      _activityBloc.cancelActivity();
+                    },
+                    width: 100,
+                    icon: activitySnapshot.data.state != ActivityState.Canceled
+                        ? const ImageIcon(AssetImage('assets/icons/cancel.png'),
+                            color: Colors.red)
+                        : const ImageIcon(AssetImage('assets/icons/undo.png'),
+                            color: Colors.blue));
+              } else {
+                return GirafButton(
+                    key: const Key('CompleteStateToggleButton'),
+                    onPressed: () {
+                      _activityBloc.completeActivity();
+                    },
+                    isEnabled:
+                        activitySnapshot.data.state != ActivityState.Canceled,
+                    width: 100,
+                    icon: activitySnapshot.data.state != ActivityState.Completed
+                        ? const ImageIcon(AssetImage('assets/icons/accept.png'),
+                            color: Colors.green)
+                        : const ImageIcon(AssetImage('assets/icons/undo.png'),
+                            color: Colors.blue));
+              }
             });
       },
     );
@@ -149,36 +175,6 @@ class ShowActivityScreen extends StatelessWidget {
               // Key is used for testing the widget.
               key: Key(_activity.id.toString()));
         });
-  }
-
-  GirafButton _buildChangeActivityStateButton(
-      ActivityState state, WeekplanMode mode) {
-    if (mode == WeekplanMode.guardian) {
-      return GirafButton(
-          key: const Key('CancelStateToggleButton'),
-          onPressed: () {
-            _activityBloc.cancelActivity();
-          },
-          width: 100,
-          icon: state != ActivityState.Canceled
-              ? const ImageIcon(AssetImage('assets/icons/cancel.png'),
-                  color: Colors.red)
-              : const ImageIcon(AssetImage('assets/icons/undo.png'),
-                  color: Colors.blue));
-    } else {
-      return GirafButton(
-          key: const Key('CompleteStateToggleButton'),
-          onPressed: () {
-            _activityBloc.completeActivity();
-          },
-          isEnabled: state != ActivityState.Canceled,
-          width: 100,
-          icon: state != ActivityState.Completed
-              ? const ImageIcon(AssetImage('assets/icons/accept.png'),
-                  color: Colors.green)
-              : const ImageIcon(AssetImage('assets/icons/undo.png'),
-                  color: Colors.blue));
-    }
   }
 
   /// Builds the icon that displays the activity's state

--- a/lib/screens/show_activity_screen.dart
+++ b/lib/screens/show_activity_screen.dart
@@ -115,54 +115,66 @@ class ShowActivityScreen extends StatelessWidget {
                       );
                     }))),
       ),
-      buildButton()
+      buildButtonBar()
     ];
   }
 
   /// Builds the button that changes the state of the activity. The content
   /// of the button depends on whether it is in guardian or citizen mode.
-  Widget buildButton() {
-    return StreamBuilder<WeekplanMode>(
-      stream: _authBloc.mode,
-      builder: (BuildContext context,
-          AsyncSnapshot<WeekplanMode> weekplanModeSnapshot) {
-        return StreamBuilder<ActivityModel>(
-            stream: _activityBloc.activityModelStream,
+  ButtonBar buildButtonBar() {
+    return ButtonBar(
+        // Key used for testing widget.
+        key: const Key('ButtonBarRender'),
+        alignment: MainAxisAlignment.center,
+        children: <Widget>[
+          StreamBuilder<WeekplanMode>(
+            stream: _authBloc.mode,
             builder: (BuildContext context,
-                AsyncSnapshot<ActivityModel> activitySnapshot) {
-              if (activitySnapshot.data == null) {
-                return const CircularProgressIndicator();
-              }
-              if (weekplanModeSnapshot.data == WeekplanMode.guardian) {
-                return GirafButton(
-                    key: const Key('CancelStateToggleButton'),
-                    onPressed: () {
-                      _activityBloc.cancelActivity();
-                    },
-                    width: 100,
-                    icon: activitySnapshot.data.state != ActivityState.Canceled
-                        ? const ImageIcon(AssetImage('assets/icons/cancel.png'),
-                            color: Colors.red)
-                        : const ImageIcon(AssetImage('assets/icons/undo.png'),
-                            color: Colors.blue));
-              } else {
-                return GirafButton(
-                    key: const Key('CompleteStateToggleButton'),
-                    onPressed: () {
-                      _activityBloc.completeActivity();
-                    },
-                    isEnabled:
-                        activitySnapshot.data.state != ActivityState.Canceled,
-                    width: 100,
-                    icon: activitySnapshot.data.state != ActivityState.Completed
-                        ? const ImageIcon(AssetImage('assets/icons/accept.png'),
-                            color: Colors.green)
-                        : const ImageIcon(AssetImage('assets/icons/undo.png'),
-                            color: Colors.blue));
-              }
-            });
-      },
-    );
+                AsyncSnapshot<WeekplanMode> weekplanModeSnapshot) {
+              return StreamBuilder<ActivityModel>(
+                  stream: _activityBloc.activityModelStream,
+                  builder: (BuildContext context,
+                      AsyncSnapshot<ActivityModel> activitySnapshot) {
+                    if (activitySnapshot.data == null) {
+                      return const CircularProgressIndicator();
+                    }
+                    if (weekplanModeSnapshot.data == WeekplanMode.guardian) {
+                      return GirafButton(
+                          key: const Key('CancelStateToggleButton'),
+                          onPressed: () {
+                            _activityBloc.cancelActivity();
+                          },
+                          width: 100,
+                          icon: activitySnapshot.data.state !=
+                                  ActivityState.Canceled
+                              ? const ImageIcon(
+                                  AssetImage('assets/icons/cancel.png'),
+                                  color: Colors.red)
+                              : const ImageIcon(
+                                  AssetImage('assets/icons/undo.png'),
+                                  color: Colors.blue));
+                    } else {
+                      return GirafButton(
+                          key: const Key('CompleteStateToggleButton'),
+                          onPressed: () {
+                            _activityBloc.completeActivity();
+                          },
+                          isEnabled: activitySnapshot.data.state !=
+                              ActivityState.Canceled,
+                          width: 100,
+                          icon: activitySnapshot.data.state !=
+                                  ActivityState.Completed
+                              ? const ImageIcon(
+                                  AssetImage('assets/icons/accept.png'),
+                                  color: Colors.green)
+                              : const ImageIcon(
+                                  AssetImage('assets/icons/undo.png'),
+                                  color: Colors.blue));
+                    }
+                  });
+            },
+          ),
+        ]);
   }
 
   /// Creates a pictogram image from the streambuilder

--- a/lib/screens/show_activity_screen.dart
+++ b/lib/screens/show_activity_screen.dart
@@ -16,10 +16,12 @@ class ShowActivityScreen extends StatelessWidget {
   ShowActivityScreen(
       WeekModel weekModel, this._activity, UsernameModel girafUser,
       {Key key})
-      : super(key: key) {
+      : _user = girafUser, super(key: key) {
     _pictoImageBloc.load(_activity.pictogram);
     _activityBloc.load(weekModel, _activity, girafUser);
   }
+
+  final UsernameModel _user;
 
   final ActivityModel _activity;
 

--- a/lib/screens/show_activity_screen.dart
+++ b/lib/screens/show_activity_screen.dart
@@ -11,8 +11,8 @@ import 'package:weekplanner/widgets/giraf_app_bar_widget.dart';
 /// Screen to show information about an activity, and change the state of it.
 class ShowActivityScreen extends StatelessWidget {
   /// Constructor
-  ShowActivityScreen(WeekModel weekModel, this._activity, UsernameModel
-  girafUser,
+  ShowActivityScreen(
+      WeekModel weekModel, this._activity, UsernameModel girafUser,
       {Key key})
       : super(key: key) {
     _pictoImageBloc.load(_activity.pictogram);
@@ -104,14 +104,7 @@ class ShowActivityScreen extends StatelessWidget {
                               width: MediaQuery.of(context).size.width,
                               height: MediaQuery.of(context).size.width,
                               child: buildLoadPictogramImage()),
-                          snapshot.data.state == ActivityState.Completed
-                              ? Icon(
-                                  Icons.check,
-                                  key: const Key('IconComplete'),
-                                  color: Colors.green,
-                                  size: MediaQuery.of(context).size.width,
-                                )
-                              : Container()
+                          _buildActivityStateIcon(context, snapshot.data.state)
                         ],
                       );
                     }))),
@@ -162,5 +155,26 @@ class ShowActivityScreen extends StatelessWidget {
               // Key is used for testing the widget.
               key: Key(_activity.id.toString()));
         });
+  }
+
+  /// Builds card that displays the activity
+  Widget _buildActivityStateIcon(BuildContext context, ActivityState state) {
+    if (state == ActivityState.Completed) {
+      return Icon(
+        Icons.check,
+        key: const Key('IconComplete'),
+        color: Colors.green,
+        size: MediaQuery.of(context).size.width,
+      );
+    } else if (state == ActivityState.Canceled) {
+      return Icon(
+        Icons.cancel,
+        key: const Key('IconCanceled'),
+        color: Colors.red,
+        size: MediaQuery.of(context).size.width,
+      );
+    } else {
+      return Container();
+    }
   }
 }

--- a/test/screens/show_activity_screen_test.dart
+++ b/test/screens/show_activity_screen_test.dart
@@ -102,14 +102,12 @@ void main() {
     expect(find.byKey(Key(mockActivity.id.toString())), findsOneWidget);
   });
 
-  testWidgets('Complete activity button is rendered in citizen mode',
-      (WidgetTester tester) async {
-    authBloc.setMode(WeekplanMode.citizen);
+  testWidgets('ButtonBar is rendered', (WidgetTester tester) async {
     await tester.pumpWidget(MaterialApp(
         home: ShowActivityScreen(mockWeek, mockActivity, mockUser)));
     await tester.pump();
 
-    expect(find.byKey(const Key('CompleteStateToggleButton')), findsOneWidget);
+    expect(find.byKey(const Key('ButtonBarRender')), findsOneWidget);
   });
 
   testWidgets('Cancel activity button is rendered in guardian mode',

--- a/test/screens/show_activity_screen_test.dart
+++ b/test/screens/show_activity_screen_test.dart
@@ -112,13 +112,54 @@ void main() {
     expect(find.byKey(const Key('CompleteStateToggleButton')), findsOneWidget);
   });
 
-  testWidgets('Activity has checkmark when done', (WidgetTester tester) async {
+  testWidgets('Cancel activity button is rendered in guardian mode',
+      (WidgetTester tester) async {
+    authBloc.setMode(WeekplanMode.guardian);
+    await tester.pumpWidget(MaterialApp(
+        home: ShowActivityScreen(mockWeek, mockActivity, mockUser)));
+    await tester.pump();
+
+    expect(find.byKey(const Key('CancelStateToggleButton')), findsOneWidget);
+  });
+
+  testWidgets('Complete activity button is NOT rendered in guardian mode',
+      (WidgetTester tester) async {
+    authBloc.setMode(WeekplanMode.guardian);
+    await tester.pumpWidget(MaterialApp(
+        home: ShowActivityScreen(mockWeek, mockActivity, mockUser)));
+    await tester.pump();
+
+    expect(find.byKey(const Key('CompleteStateToggleButton')), findsNothing);
+  });
+
+  testWidgets('Cancel activity button is NOT rendered in citizen mode',
+      (WidgetTester tester) async {
+    authBloc.setMode(WeekplanMode.citizen);
+    await tester.pumpWidget(MaterialApp(
+        home: ShowActivityScreen(mockWeek, mockActivity, mockUser)));
+    await tester.pump();
+
+    expect(find.byKey(const Key('CancelStateToggleButton')), findsNothing);
+  });
+
+  testWidgets('Activity has checkmark icon when completed',
+      (WidgetTester tester) async {
     mockActivity.state = ActivityState.Completed;
     await tester.pumpWidget(MaterialApp(
         home: ShowActivityScreen(mockWeek, mockActivity, mockUser)));
     await tester.pump();
 
     expect(find.byKey(const Key('IconCompleted')), findsOneWidget);
+  });
+
+  testWidgets('Activity has cancel icon when canceled',
+      (WidgetTester tester) async {
+    mockActivity.state = ActivityState.Canceled;
+    await tester.pumpWidget(MaterialApp(
+        home: ShowActivityScreen(mockWeek, mockActivity, mockUser)));
+    await tester.pump();
+
+    expect(find.byKey(const Key('IconCanceled')), findsOneWidget);
   });
 
   testWidgets('Activity has no checkmark when Normal',
@@ -131,7 +172,7 @@ void main() {
     expect(find.byKey(const Key('IconCompleted')), findsNothing);
   });
 
-  testWidgets('Activity is set to completed and an activity mark is shown',
+  testWidgets('Activity is set to completed and an activity checkmark is shown',
       (WidgetTester tester) async {
     authBloc.setMode(WeekplanMode.citizen);
     mockActivity.state = ActivityState.Normal;
@@ -145,7 +186,21 @@ void main() {
     expect(find.byKey(const Key('IconCompleted')), findsOneWidget);
   });
 
-  testWidgets('Activity is set to normal and an activity mark is not shown',
+  testWidgets('Activity is set to canceled and an activity cross is shown',
+      (WidgetTester tester) async {
+    authBloc.setMode(WeekplanMode.guardian);
+    mockActivity.state = ActivityState.Normal;
+    await tester.pumpWidget(MaterialApp(
+        home: ShowActivityScreen(mockWeek, mockActivity, mockUser)));
+
+    await tester.pump();
+    await tester.tap(find.byKey(const Key('CancelStateToggleButton')));
+
+    await tester.pump();
+    expect(find.byKey(const Key('IconCanceled')), findsOneWidget);
+  });
+
+  testWidgets('Activity is set to normal and no activity mark is shown',
       (WidgetTester tester) async {
     authBloc.setMode(WeekplanMode.citizen);
     mockActivity.state = ActivityState.Completed;
@@ -157,5 +212,6 @@ void main() {
 
     await tester.pump();
     expect(find.byKey(const Key('IconCompleted')), findsNothing);
+    expect(find.byKey(const Key('IconCanceled')), findsNothing);
   });
 }


### PR DESCRIPTION
This closes #58.

ShowActivityScreen when in guardian mode and activity is canceled:
![image](https://user-images.githubusercontent.com/26706527/57216151-5676bd80-6fef-11e9-8712-463d48ff0730.png)

ShowActivityScreen when in citizen mode and activity is complete:
![image](https://user-images.githubusercontent.com/26706527/57216200-7e662100-6fef-11e9-8d94-b8073ec86a83.png)

ShowActivityScreen when in citizen mode and activity is canceled (button is disabled):
![image](https://user-images.githubusercontent.com/26706527/57216270-b1a8b000-6fef-11e9-852a-6e010e27749d.png)
