### PR TITLE
Revert "Feature 157 and 112"

### DIFF
--- a/lib/blocs/auth_bloc.dart
+++ b/lib/blocs/auth_bloc.dart
@@ -1,10 +1,7 @@
 import 'package:api_client/api/api.dart';
-import 'package:flutter/material.dart';
 import 'package:rxdart/rxdart.dart';
 import 'package:weekplanner/blocs/bloc_base.dart';
 import 'package:weekplanner/models/enums/weekplan_mode.dart';
-import 'package:weekplanner/routes.dart';
-import 'package:weekplanner/widgets/giraf_notify_dialog.dart';
 
 /// All about Authentication. Login, logout, etc.
 class AuthBloc extends BlocBase {
@@ -22,8 +19,7 @@ class AuthBloc extends BlocBase {
 
   /// Start with providing false as the logged in status
   final BehaviorSubject<bool> _loggedIn = BehaviorSubject<bool>.seeded(false);
-
-  /// Reflect the current clearence level of the user
+  /// Reflect the current clearance level of the user
   final BehaviorSubject<WeekplanMode> _mode =
   BehaviorSubject<WeekplanMode>.seeded(WeekplanMode.guardian);
 
@@ -45,48 +41,6 @@ class AuthBloc extends BlocBase {
         setMode(WeekplanMode.guardian);
       }
     });
-  }
-
-  /// Indicates whether the last login attempt was succesfull.
-  bool _loginStatus = false;
-
-  /// Shows a failure dialog
-  void _showFailureDialog(BuildContext context){
-    showDialog<Center>(
-        barrierDismissible: false,
-        context: context,
-        builder: (BuildContext context) {
-          return const GirafNotifyDialog(
-              title: 'Fejl',
-              description: 'Forkert adgangskode',
-              key: Key('WrongUsernameOrPasswordDialog'));
-        });
-  }
-
-  /// Authenticates the user only by password when signing-in from PopUp.
-  void authenticateFromPopUp(String username, String password,
-                             BuildContext context) {
-    // Make sure the status for the upcoming
-    // login is false until proven otherwise
-    _loginStatus = false;
-
-    _api.account.login(username, password).take(1).listen((bool status) {
-      if (status) {
-        _loginStatus = true;
-        }
-    }).onDone(() => _evaluateLogin(context));
-  }
-
-  /// used to evaluate the login attempt when loggin in from popup.
-  void _evaluateLogin(BuildContext context)
-  {
-    if (_loginStatus){
-      Routes.pop(context);
-      setMode(WeekplanMode.guardian);
-    }
-    else {
-      _showFailureDialog(context);
-    }
   }
 
   /// Logs the currently logged in user out

--- a/lib/blocs/toolbar_bloc.dart
+++ b/lib/blocs/toolbar_bloc.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:flutter/material.dart';
 import 'package:rxdart/rxdart.dart';
 import 'package:weekplanner/blocs/bloc_base.dart';
@@ -15,11 +13,8 @@ import 'package:weekplanner/widgets/giraf_confirm_dialog.dart';
 /// Contains the functionality of the toolbar.
 class ToolbarBloc extends BlocBase {
 
-  /// If the confirm button in popup is clickable.
-  bool _clickable = true;
-
   final BehaviorSubject<List<IconButton>> _visibleButtons =
-  BehaviorSubject<List<IconButton>>.seeded(<IconButton>[]);
+      BehaviorSubject<List<IconButton>>.seeded(<IconButton>[]);
 
   /// The current visibility of the edit-button.
   Stream<List<IconButton>> get visibleButtons => _visibleButtons.stream;
@@ -33,10 +28,10 @@ class ToolbarBloc extends BlocBase {
 
     // Assigns a map to icons, if icons is null.
     icons ??= <AppBarIcon, VoidCallback>{
-      AppBarIcon.settings: null,
-      AppBarIcon.logout: null
-    };
-
+        AppBarIcon.settings: null,
+        AppBarIcon.logout: null
+      };
+    
     for (AppBarIcon icon in icons.keys) {
       _addIconButton(_iconsToAdd, icon, icons[icon], context);
     }
@@ -242,21 +237,10 @@ class ToolbarBloc extends BlocBase {
             buttons: <DialogButton>[
               DialogButton(
                 key: const Key('SwitchToGuardianSubmit'),
-                  // Debouncer for button, so it cannot
-                  // be tapped than each 2 seconds.
-                  onPressed: _clickable
-                      ? () {
-                    if (_clickable) {
-                      _clickable = false;
-                      loginFromPopUp(context, _authBloc.loggedInUsername,
-                          passwordCtrl.value.text);
-                      // Timer makes it clicable again after 2 seconds.
-                      Timer(const Duration(milliseconds: 2000), () {
-                        _clickable = true;
-                      });
-                    }
-                  }
-                  : null,
+                onPressed: () {
+                  login(_authBloc.loggedInUsername, passwordCtrl.value.text);
+                  Routes.pop(context);
+                },
                 child: const Text(
                   'Bekræft',
                   style: TextStyle(color: Colors.white, fontSize: 20),
@@ -322,7 +306,7 @@ class ToolbarBloc extends BlocBase {
                 description: 'Vil du logge ud?',
                 confirmButtonText: 'Log ud',
                 confirmButtonIcon:
-                const ImageIcon(AssetImage('assets/icons/logout.png')),
+                    const ImageIcon(AssetImage('assets/icons/logout.png')),
                 confirmOnPressed: () => _authBloc.logout(),
               );
             });
@@ -397,9 +381,9 @@ class ToolbarBloc extends BlocBase {
     ),
   );
 
-  /// Used to authenticate a user from popup.
-  void loginFromPopUp(BuildContext context, String username, String password) {
-    _authBloc.authenticateFromPopUp(username, password, context);
+  /// Used to authenticate a user.
+  void login(String username, String password) {
+    _authBloc.authenticate(username, password);
   }
 
   @override

--- a/test/screens/weekplan_screen_test.dart
+++ b/test/screens/weekplan_screen_test.dart
@@ -38,8 +38,7 @@ class MockAuthBlock extends AuthBloc {
   MockAuthBlock(Api api) : super(api);
 
   @override
-  void authenticateFromPopUp(String username, String password,
-                             BuildContext context) {
+  void authenticate(String username, String password) {
     if (password == 'password') {
       setMode(WeekplanMode.guardian);
     }
@@ -499,7 +498,7 @@ void main() {
   });
 
   testWidgets(
-      'In the switch to guardian dialog, confirming should switch mode',
+      'In the switch to guardian dialog, confirming should switch mode and pop',
       (WidgetTester tester) async {
     final Completer<bool> done = Completer<bool>();
     final Completer<bool> tapComplete = Completer<bool>();
@@ -528,9 +527,14 @@ void main() {
         find.byKey(const Key('SwitchToGuardianPassword')), 'password');
     await tester.tap(find.byKey(const Key('SwitchToGuardianSubmit')));
 
-    await tester.pumpAndSettle(const Duration(seconds:1));
+    await tester.pumpAndSettle();
 
     tapComplete.complete();
+
+    final VerificationResult verificationResult =
+        verify(observer.didPop(captureAny, captureAny));
+
+    expect(verificationResult.callCount, equals(1));
 
     await done.future;
   });

--- a/test/widgets/giraf_app_bar_widget_test.dart
+++ b/test/widgets/giraf_app_bar_widget_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -10,7 +11,6 @@ import 'package:weekplanner/models/enums/app_bar_icons_enum.dart';
 import 'package:weekplanner/widgets/giraf_app_bar_widget.dart';
 import 'package:mockito/mockito.dart';
 import 'package:weekplanner/widgets/giraf_confirm_dialog.dart';
-import 'package:weekplanner/widgets/giraf_notify_dialog.dart';
 
 class MockAuth extends Mock implements AuthBloc {
   @override
@@ -21,8 +21,7 @@ class MockAuth extends Mock implements AuthBloc {
   String loggedInUsername = 'Graatand';
 
   @override
-  void authenticateFromPopUp(String username, String password,
-                             BuildContext context) {
+  void authenticate(String username, String password) {
     // Mock the API and allow these 2 users to ?login?
     final bool status = (username == 'test' && password == 'test') ||
         (username == 'Graatand' && password == 'password');
@@ -31,25 +30,8 @@ class MockAuth extends Mock implements AuthBloc {
     if (status) {
       loggedInUsername = username;
     }
-    else {
-      showFailureDialog(context);
-    }
     _loggedIn.add(status);
   }
-
-  //Shows the failure dialog when wrong credentials when logging in from popup.
-  void showFailureDialog(BuildContext context){
-    showDialog<Center>(
-        barrierDismissible: false,
-        context: context,
-        builder: (BuildContext context) {
-          return const GirafNotifyDialog(
-              title: 'Fejl',
-              description: 'Forkert adgangskode',
-              key: Key('WrongUsernameOrPasswordDialog'));
-        });
-  }
-
 
   @override
   void logout() {
@@ -63,19 +45,13 @@ class MockScreen extends StatelessWidget {
     return Scaffold(
         appBar: GirafAppBar(
             title: 'TestTitle',
-            appBarIcons: <AppBarIcon, VoidCallback>{
-              AppBarIcon.logout: null,
-              AppBarIcon.changeToGuardian: () {},
-            }));
+            appBarIcons: const <AppBarIcon, VoidCallback>{
+              AppBarIcon.logout: null}));
   }
 }
 
 /// Used to retrieve the visibility widget wrapping the editbutton
 const String keyOfVisibilityForEdit = 'visibilityEditBtn';
-const String keyOfWrongUsernameOrPassword = 'WrongUsernameOrPasswordDialog';
-const String keyOfChangeToGuardian = 'IconChangeToGuardian';
-const String keyOfPasswordField = 'SwitchToGuardianPassword';
-const String keyOfConfirmButton = 'SwitchToGuardianSubmit';
 
 void main() {
   ToolbarBloc bloc;
@@ -380,42 +356,5 @@ void main() {
       }
     });
     await done.future;
-  });
-
-  testWidgets('Dialog should not be visible', (WidgetTester tester) async {
-    await tester.pumpWidget(makeTestableWidget(child: MockScreen()));
-    await tester.pumpAndSettle();
-
-    await tester.tap(find.byKey(const Key(keyOfChangeToGuardian)));
-    await tester.pumpAndSettle();
-
-    await tester.enterText(find.byKey(const Key(keyOfPasswordField)),
-        'password');
-    await tester.pumpAndSettle();
-
-    await tester.tap(find.byKey(const Key(keyOfConfirmButton)));
-    await tester.pumpAndSettle(const Duration(seconds: 2));
-
-    expect(find.byKey(const Key(keyOfWrongUsernameOrPassword)),
-        findsNothing);
-  });
-
-
-  testWidgets('Dialog should be visible', (WidgetTester tester) async {
-    await tester.pumpWidget(makeTestableWidget(child: MockScreen()));
-    await tester.pumpAndSettle();
-
-    await tester.tap(find.byKey(const Key(keyOfChangeToGuardian)));
-    await tester.pumpAndSettle();
-
-    await tester.enterText(find.byKey(const Key(keyOfPasswordField)),
-        'wrongpassword');
-    await tester.pumpAndSettle();
-
-    await tester.tap(find.byKey(const Key(keyOfConfirmButton)));
-    await tester.pumpAndSettle(const Duration(seconds: 2));
-
-    expect(find.byKey(const Key(keyOfWrongUsernameOrPassword)),
-        findsOneWidget);
   });
 }


### PR DESCRIPTION
Reverts aau-giraf/weekplanner#172

#172 breaks the bloc structure by having BuildContext in Blocs. This needs to be resolved before this should be merged into Develop.

Keep in mind that if we break the bloc structure, it is very hard to argue why the next students to look at Giraf should follow it. 

There are also several bugs:

- Loading spinner is not shown every time login is pressed
- The Wrong Username/Password dialog is not always shown
- Sometimes the Login Screen is pop'ed resulting in black screen
- Sometimes the Wrong Username/Password dialog is shown, but not dismissed resulting in an exception and the dialog being shown on ChooseCitizenScreen