### PR TITLE
fixed issues described in issue #259, inconsistent design

### DIFF
--- a/lib/screens/weekplan_screen.dart
+++ b/lib/screens/weekplan_screen.dart
@@ -170,7 +170,7 @@ class WeekplanScreen extends StatelessWidget {
                 'kopieres til',
             confirmButtonText: 'Kopier',
             confirmButtonIcon:
-                const ImageIcon(AssetImage('assets/icons/accept.png')),
+                const ImageIcon(AssetImage('assets/icons/copy.png')),
             confirmOnPressed: _copyActivities,
           );
         });
@@ -183,7 +183,7 @@ class WeekplanScreen extends StatelessWidget {
         context: context,
         builder: (BuildContext context) {
           return GirafConfirmDialog(
-              title: 'Bekræft',
+              title: 'Annuller aktiviteter',
               description: 'Vil du markere ' +
                   _weekplanBloc.getNumberOfMarkedActivities().toString() +
                   ' aktivitet(er) som annulleret',
@@ -207,13 +207,13 @@ class WeekplanScreen extends StatelessWidget {
         context: context,
         builder: (BuildContext context) {
           return GirafConfirmDialog(
-              title: 'Bekræft',
+              title: 'Slet aktiviteter',
               description: 'Vil du slette ' +
                   _weekplanBloc.getNumberOfMarkedActivities().toString() +
                   ' aktivitet(er)',
-              confirmButtonText: 'Bekræft',
+              confirmButtonText: 'Slet',
               confirmButtonIcon:
-                  const ImageIcon(AssetImage('assets/icons/accept.png')),
+                  const ImageIcon(AssetImage('assets/icons/delete.png')),
               confirmOnPressed: () {
                 _weekplanBloc.deleteMarkedActivities();
                 _weekplanBloc.toggleEditMode();

--- a/lib/screens/weekplan_selector_screen.dart
+++ b/lib/screens/weekplan_selector_screen.dart
@@ -231,13 +231,13 @@ class WeekplanSelectorScreen extends StatelessWidget {
         context: context,
         builder: (BuildContext context) {
           return GirafConfirmDialog(
-              title: 'Bekræft',
+              title: 'Slet ugeplaner',
               description: 'Vil du slette ' +
                   _weekBloc.getNumberOfMarkedWeekModels().toString() +
                   ' ugeplan(er)',
-              confirmButtonText: 'Bekræft',
+              confirmButtonText: 'Slet',
               confirmButtonIcon:
-                  const ImageIcon(AssetImage('assets/icons/accept.png')),
+                  const ImageIcon(AssetImage('assets/icons/delete.png')),
               confirmOnPressed: () {
                 _weekBloc.deleteMarkedWeekModels();
                 _weekBloc.toggleEditMode();


### PR DESCRIPTION
This closes #259 .
Screens showed in #259 have been corrected to the suggested changes, making the texts and icons consistent with the rest of the application. 

Some overflow issues still occur, but is a seperate issue: #255 

![image](https://user-images.githubusercontent.com/26058779/57619713-ee901c00-7586-11e9-8e78-01ba5d1c313b.png)

![image](https://user-images.githubusercontent.com/26058779/57619719-f223a300-7586-11e9-9a26-fbc8ca29db8e.png)

![image](https://user-images.githubusercontent.com/26058779/57619722-f51e9380-7586-11e9-84e7-dcc12ce2e087.png)

![image](https://user-images.githubusercontent.com/26058779/57619725-f8198400-7586-11e9-9ac7-63af0f37aab5.png)
