### PR TITLE
Release fix/254 

### DIFF
--- a/lib/widgets/giraf_activity_time_picker_dialog.dart
+++ b/lib/widgets/giraf_activity_time_picker_dialog.dart
@@ -155,7 +155,7 @@ class GirafActivityTimerPickerDialog extends StatelessWidget {
           builder: (BuildContext context) {
             return GirafNotifyDialog(
                 key: const Key('TimerWrongInputKey'),
-                title: 'Forkert input',
+                title: 'Ugyldigt input',
                 description: (duration.inSeconds == 0 &&
                             (_textEditingControllerHours.text != '' &&
                                 _textEditingControllerHours.text != '0') ||

--- a/lib/widgets/giraf_activity_time_picker_dialog.dart
+++ b/lib/widgets/giraf_activity_time_picker_dialog.dart
@@ -7,7 +7,6 @@ import 'package:weekplanner/widgets/giraf_button_widget.dart';
 import 'package:weekplanner/widgets/giraf_notify_dialog.dart';
 import 'package:weekplanner/widgets/giraf_title_header.dart';
 
-
 /// The acitivty time picker dialog is a dialog, asking for a duration input.
 /// The duration should be inserted in the textfield, and the user can either
 /// cancel the dialog, or confirm to create the timer for the activity.
@@ -15,10 +14,10 @@ class GirafActivityTimerPickerDialog extends StatelessWidget {
   /// The activity time picker takes the activity as input, to insert a timer
   /// to the given activity.
   GirafActivityTimerPickerDialog(
-    this._activity,
-    this._timerBloc, {
-    Key key,
-  }) : super(key: key) {
+      this._activity,
+      this._timerBloc, {
+        Key key,
+      }) : super(key: key) {
     _timerBloc.load(_activity);
   }
 
@@ -26,11 +25,11 @@ class GirafActivityTimerPickerDialog extends StatelessWidget {
   final TimerBloc _timerBloc;
 
   final TextEditingController _textEditingControllerHours =
-      TextEditingController();
+  TextEditingController();
   final TextEditingController _textEditingControllerMinutes =
-      TextEditingController();
+  TextEditingController();
   final TextEditingController _textEditingControllerSeconds =
-      TextEditingController();
+  TextEditingController();
 
   @override
   Widget build(BuildContext context) {
@@ -42,8 +41,8 @@ class GirafActivityTimerPickerDialog extends StatelessWidget {
             color: const Color.fromRGBO(112, 112, 112, 1), width: 5.0),
         title: const Center(
             child: GirafTitleHeader(
-          title: 'Vælg tid for aktivitet',
-        )),
+              title: 'Vælg tid for aktivitet',
+            )),
         content: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           mainAxisSize: MainAxisSize.min,
@@ -125,6 +124,7 @@ class GirafActivityTimerPickerDialog extends StatelessWidget {
                     hintText: '',
                   ),
                   inputFormatters: <TextInputFormatter>[
+                    WhitelistingTextInputFormatter(RegExp('[0-9]*')),
                     LengthLimitingTextInputFormatter(2)
                   ]),
             ),
@@ -153,18 +153,11 @@ class GirafActivityTimerPickerDialog extends StatelessWidget {
           context: context,
           barrierDismissible: false,
           builder: (BuildContext context) {
-            return GirafNotifyDialog(
-                key: const Key('TimerWrongInputKey'),
-                title: 'Ugyldigt input',
-                description: (duration.inSeconds == 0 &&
-                            (_textEditingControllerHours.text != '' &&
-                                _textEditingControllerHours.text != '0') ||
-                        (_textEditingControllerMinutes.text != '' &&
-                            _textEditingControllerMinutes.text != '0') ||
-                        (_textEditingControllerSeconds.text != '' &&
-                            _textEditingControllerSeconds.text != '0'))
-                    ? 'Teksttfelterne må kun indholde tal'
-                    : 'Den indtastede tid må ikke være 0');
+            return const GirafNotifyDialog(
+              key: Key('TimerWrongInputKey'),
+              title: 'Ugyldigt input',
+              description: 'Den valgte tid må ikke være 0',
+            );
           });
     }
   }

--- a/lib/widgets/giraf_activity_time_picker_dialog.dart
+++ b/lib/widgets/giraf_activity_time_picker_dialog.dart
@@ -6,6 +6,8 @@ import 'package:weekplanner/routes.dart';
 import 'package:weekplanner/widgets/giraf_button_widget.dart';
 import 'package:weekplanner/widgets/giraf_title_header.dart';
 
+import 'giraf_notify_dialog.dart';
+
 /// The acitivty time picker dialog is a dialog, asking for a duration input.
 /// The duration should be inserted in the textfield, and the user can either
 /// cancel the dialog, or confirm to create the timer for the activity.
@@ -143,10 +145,27 @@ class GirafActivityTimerPickerDialog extends StatelessWidget {
       seconds: seconds,
     );
 
-    if (duration.inSeconds != 0 && hours >= 0 && minutes >= 0 && seconds >= 0)
-    {
+    if (duration.inSeconds != 0 && hours >= 0 && minutes >= 0 && seconds >= 0) {
       _timerBloc.addTimer(duration);
       Routes.pop(context);
+    } else {
+      showDialog<Center>(
+          context: context,
+          barrierDismissible: false,
+          builder: (BuildContext context) {
+            return GirafNotifyDialog(
+                key: const Key('TimerWrongInputKey'),
+                title: 'Forkert input',
+                description: (duration.inSeconds == 0 &&
+                            (_textEditingControllerHours.text != '' &&
+                                _textEditingControllerHours.text != '0') ||
+                        (_textEditingControllerMinutes.text != '' &&
+                            _textEditingControllerMinutes.text != '0') ||
+                        (_textEditingControllerSeconds.text != '' &&
+                            _textEditingControllerSeconds.text != '0'))
+                    ? 'Teksttfelterne må kun indholde tal'
+                    : 'Den indtastede tid må ikke være 0');
+          });
     }
   }
 }

--- a/lib/widgets/giraf_activity_time_picker_dialog.dart
+++ b/lib/widgets/giraf_activity_time_picker_dialog.dart
@@ -4,9 +4,9 @@ import 'package:flutter/services.dart';
 import 'package:weekplanner/blocs/timer_bloc.dart';
 import 'package:weekplanner/routes.dart';
 import 'package:weekplanner/widgets/giraf_button_widget.dart';
+import 'package:weekplanner/widgets/giraf_notify_dialog.dart';
 import 'package:weekplanner/widgets/giraf_title_header.dart';
 
-import 'giraf_notify_dialog.dart';
 
 /// The acitivty time picker dialog is a dialog, asking for a duration input.
 /// The duration should be inserted in the textfield, and the user can either

--- a/test/widgets/giraf_activity_time_picker_dialog_test.dart
+++ b/test/widgets/giraf_activity_time_picker_dialog_test.dart
@@ -158,4 +158,54 @@ void main() {
         const Duration(hours: hours, minutes: minutes, seconds: seconds)
             .inMilliseconds);
   });
+
+
+  testWidgets(
+      'Test that wrong input on textfields prompts a notify dialog'
+          'with correct message', (WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(home: MockScreen()));
+    await tester.tap(find.byKey(const Key('TimePickerOpenButton')));
+    await tester.pump();
+    await tester.enterText(find.byKey(const Key('TimerTextFieldKey')), 'ab');
+    await tester.pump();
+    await tester.enterText(
+        find.byKey(const Key('MinutterTextFieldKey')), 'cd');
+    await tester.pump();
+    await tester.enterText(
+        find.byKey(const Key('SekunderTextFieldKey')), 'ef');
+    await tester.pump();
+    await tester.tap(find.byKey(const Key('TimePickerDialogAcceptButton')));
+    await tester.pumpAndSettle();
+    expect(find.text('Teksttfelterne må kun indholde tal'), findsOneWidget);
+  });
+
+  testWidgets(
+      'Test that wrong 0 time input on textfields prompts a notify dialog'
+          'with correct message', (WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(home: MockScreen()));
+    await tester.tap(find.byKey(const Key('TimePickerOpenButton')));
+    await tester.pump();
+    await tester.enterText(find.byKey(const Key('TimerTextFieldKey')), '0');
+    await tester.pump();
+    await tester.enterText(
+        find.byKey(const Key('MinutterTextFieldKey')), '0');
+    await tester.pump();
+    await tester.enterText(
+        find.byKey(const Key('SekunderTextFieldKey')), '0');
+    await tester.pump();
+    await tester.tap(find.byKey(const Key('TimePickerDialogAcceptButton')));
+    await tester.pump();
+    expect(find.text('Den indtastede tid må ikke være 0'), findsOneWidget);
+  });
+
+  testWidgets(
+      'Test that no input on textfields prompts a notify dialog'
+          'with correct message', (WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(home: MockScreen()));
+    await tester.tap(find.byKey(const Key('TimePickerOpenButton')));
+    await tester.pump();
+    await tester.tap(find.byKey(const Key('TimePickerDialogAcceptButton')));
+    await tester.pump();
+    expect(find.text('Den indtastede tid må ikke være 0'), findsOneWidget);
+  });
 }

--- a/test/widgets/giraf_activity_time_picker_dialog_test.dart
+++ b/test/widgets/giraf_activity_time_picker_dialog_test.dart
@@ -159,26 +159,6 @@ void main() {
             .inMilliseconds);
   });
 
-
-  testWidgets(
-      'Test that wrong input on textfields prompts a notify dialog'
-          'with correct message', (WidgetTester tester) async {
-    await tester.pumpWidget(MaterialApp(home: MockScreen()));
-    await tester.tap(find.byKey(const Key('TimePickerOpenButton')));
-    await tester.pump();
-    await tester.enterText(find.byKey(const Key('TimerTextFieldKey')), 'ab');
-    await tester.pump();
-    await tester.enterText(
-        find.byKey(const Key('MinutterTextFieldKey')), 'cd');
-    await tester.pump();
-    await tester.enterText(
-        find.byKey(const Key('SekunderTextFieldKey')), 'ef');
-    await tester.pump();
-    await tester.tap(find.byKey(const Key('TimePickerDialogAcceptButton')));
-    await tester.pumpAndSettle();
-    expect(find.text('Teksttfelterne må kun indholde tal'), findsOneWidget);
-  });
-
   testWidgets(
       'Test that wrong 0 time input on textfields prompts a notify dialog'
           'with correct message', (WidgetTester tester) async {
@@ -195,7 +175,7 @@ void main() {
     await tester.pump();
     await tester.tap(find.byKey(const Key('TimePickerDialogAcceptButton')));
     await tester.pump();
-    expect(find.text('Den indtastede tid må ikke være 0'), findsOneWidget);
+    expect(find.text('Den valgte tid må ikke være 0'), findsOneWidget);
   });
 
   testWidgets(
@@ -206,6 +186,6 @@ void main() {
     await tester.pump();
     await tester.tap(find.byKey(const Key('TimePickerDialogAcceptButton')));
     await tester.pump();
-    expect(find.text('Den indtastede tid må ikke være 0'), findsOneWidget);
+    expect(find.text('Den valgte tid må ikke være 0'), findsOneWidget);
   });
 }


### PR DESCRIPTION
This closes #254 
When adding a timer, putting letters or other symbols in the textfields now promts with an error message, notifying what is allowed.

![image](https://user-images.githubusercontent.com/26058779/57626317-edb2b680-7595-11e9-8d1b-3905bd388b71.png)

![image](https://user-images.githubusercontent.com/26058779/57626332-f4d9c480-7595-11e9-9692-f244081e23b4.png)
