### PR TITLE
added .flutter-plugins-dependencies to the gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@
 **/doc/api/
 .dart_tool/
 .flutter-plugins
+.flutter-plugins-dependencies
 .packages
 .pub-cache/
 .pub/


### PR DESCRIPTION
this is done according to https://gitignore.io/api/flutter