### PR TITLE
Update weekplan_screen.dart 

### DIFF
--- a/lib/screens/weekplan_screen.dart
+++ b/lib/screens/weekplan_screen.dart
@@ -45,7 +45,7 @@ class WeekplanScreen extends StatelessWidget {
   final AuthBloc _authBloc = di.getDependency<AuthBloc>();
   final UsernameModel _user;
   final WeekModel _week;
-  final AutoSizeGroup _cardAutoSizeGroup = new AutoSizeGroup();
+  final AutoSizeGroup _cardAutoSizeGroup = AutoSizeGroup();
 
   @override
   Widget build(BuildContext context) {

--- a/lib/screens/weekplan_screen.dart
+++ b/lib/screens/weekplan_screen.dart
@@ -45,6 +45,7 @@ class WeekplanScreen extends StatelessWidget {
   final AuthBloc _authBloc = di.getDependency<AuthBloc>();
   final UsernameModel _user;
   final WeekModel _week;
+  final AutoSizeGroup _cardAutoSizeGroup = new AutoSizeGroup();
 
   @override
   Widget build(BuildContext context) {
@@ -584,6 +585,7 @@ class WeekplanScreen extends StatelessWidget {
       key: Key(translation),
       color: buttonColor,
       child: ListTile(
+        contentPadding: const EdgeInsets.all(0.0), // Sets padding in cards
         title: AutoSizeText(
           translation,
           style: const TextStyle(
@@ -592,6 +594,7 @@ class WeekplanScreen extends StatelessWidget {
           textAlign: TextAlign.center,
           maxLines: 1,
           minFontSize: 8,
+          group: _cardAutoSizeGroup,
         ),
       ),
     );

--- a/lib/screens/weekplan_screen.dart
+++ b/lib/screens/weekplan_screen.dart
@@ -593,7 +593,6 @@ class WeekplanScreen extends StatelessWidget {
           ),
           textAlign: TextAlign.center,
           maxLines: 1,
-          minFontSize: 8,
           group: _cardAutoSizeGroup,
         ),
       ),

--- a/lib/screens/weekplan_screen.dart
+++ b/lib/screens/weekplan_screen.dart
@@ -590,6 +590,7 @@ class WeekplanScreen extends StatelessWidget {
           translation,
           style: const TextStyle(
             fontWeight: FontWeight.bold,
+            fontSize: 30.0,
           ),
           textAlign: TextAlign.center,
           maxLines: 1,

--- a/lib/screens/weekplan_screen.dart
+++ b/lib/screens/weekplan_screen.dart
@@ -5,6 +5,7 @@ import 'package:api_client/models/pictogram_model.dart';
 import 'package:api_client/models/username_model.dart';
 import 'package:api_client/models/week_model.dart';
 import 'package:api_client/models/weekday_model.dart';
+import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 import 'package:tuple/tuple.dart';
 import 'package:weekplanner/blocs/auth_bloc.dart';
@@ -583,12 +584,14 @@ class WeekplanScreen extends StatelessWidget {
       key: Key(translation),
       color: buttonColor,
       child: ListTile(
-        title: Text(
+        title: AutoSizeText(
           translation,
           style: const TextStyle(
             fontWeight: FontWeight.bold,
           ),
           textAlign: TextAlign.center,
+          maxLines: 1,
+          minFontSize: 8,
         ),
       ),
     );


### PR DESCRIPTION
Changed to use AutoSizeText() instead of Text() for the Card widget in in weekplan_screen.dart

Fixes #233 
![Udklip](https://user-images.githubusercontent.com/34282060/75770613-9100d200-5d48-11ea-8dac-e831d2f8d776.PNG)


