### PR TITLE
Update the build status badge to GH Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Weekplanner
 
-[![Build Status](https://dev.azure.com/aau-giraf/giraf/_apis/build/status/aau-giraf.weekplanner?branchName=master)](https://dev.azure.com/aau-giraf/giraf/_build/latest?definitionId=2&branchName=master)
+![Build Status](https://github.com/aau-giraf/weekplanner/workflows/CI/badge.svg)
 
 This is the ongoing project on moving from Xamarin to Flutter.
 

--- a/README.md
+++ b/README.md
@@ -39,4 +39,4 @@ When creating a new branch for this project. One should stay on the Weekplanner-
 
 GNU GENERAL PUBLIC LICENSE V3
 
-Copyright [2018] [Aalborg University]
+Copyright [2020] [Aalborg University]


### PR DESCRIPTION
closes #329

The badge is taken directly from the GitHub Actions pane "Create status badge"