### PR TITLE
Feature 228

### DIFF
--- a/lib/blocs/toolbar_bloc.dart
+++ b/lib/blocs/toolbar_bloc.dart
@@ -12,6 +12,7 @@ import 'package:weekplanner/screens/settings_screen.dart';
 import 'package:weekplanner/widgets/giraf_confirm_dialog.dart';
 import 'package:weekplanner/widgets/giraf_notify_dialog.dart';
 import 'package:weekplanner/widgets/loading_spinner_widget.dart';
+import '../style/custom_color.dart' as theme;
 
 /// Contains the functionality of the toolbar.
 class ToolbarBloc extends BlocBase {
@@ -275,7 +276,7 @@ class ToolbarBloc extends BlocBase {
               'Bekræft',
               style: TextStyle(color: Colors.white, fontSize: 20),
             ),
-            color: const Color.fromRGBO(255, 157, 0, 100),
+            color: theme.GirafColors.dialogButton,
           )
         ]);
   }

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -117,7 +117,7 @@ class LoginScreenState extends State<LoginScreen> {
                           decoration: const InputDecoration.collapsed(
                             hintText: 'Brugernavn',
                             hintStyle: TextStyle(
-                                color: theme.GirafColors.transparentGrey),
+                                color: theme.GirafColors.loginFieldText),
                             fillColor: Colors.white,
                           ),
                         ),
@@ -140,7 +140,7 @@ class LoginScreenState extends State<LoginScreen> {
                           decoration: const InputDecoration.collapsed(
                             hintText: 'Adgangskode',
                             hintStyle: TextStyle(
-                                color: theme.GirafColors.transparentGrey),
+                                color: theme.GirafColors.loginFieldText),
                             fillColor: Colors.white,
                           ),
                         ),

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -5,6 +5,7 @@ import 'package:weekplanner/providers/environment_provider.dart' as environment;
 import 'package:weekplanner/routes.dart';
 import 'package:weekplanner/widgets/giraf_notify_dialog.dart';
 import 'package:weekplanner/widgets/loading_spinner_widget.dart';
+import '../style/custom_color.dart' as theme;
 
 /// Logs the user in
 class LoginScreen extends StatefulWidget {
@@ -116,7 +117,7 @@ class LoginScreenState extends State<LoginScreen> {
                           decoration: const InputDecoration.collapsed(
                             hintText: 'Brugernavn',
                             hintStyle: TextStyle(
-                                color: Color.fromRGBO(170, 170, 170, 1)),
+                                color: theme.GirafColors.transparentGrey),
                             fillColor: Colors.white,
                           ),
                         ),
@@ -139,7 +140,7 @@ class LoginScreenState extends State<LoginScreen> {
                           decoration: const InputDecoration.collapsed(
                             hintText: 'Adgangskode',
                             hintStyle: TextStyle(
-                                color: Color.fromRGBO(170, 170, 170, 1)),
+                                color: theme.GirafColors.transparentGrey),
                             fillColor: Colors.white,
                           ),
                         ),
@@ -161,7 +162,7 @@ class LoginScreenState extends State<LoginScreen> {
                             onPressed: () {
                               loginAction(context);
                             },
-                            color: const Color.fromRGBO(48, 81, 118, 1),
+                            color: theme.GirafColors.loginButtonColor,
                           ),
                         ),
                       ),
@@ -186,7 +187,7 @@ class LoginScreenState extends State<LoginScreen> {
                                       environment.getVar<String>('PASSWORD');
                                   loginAction(context);
                                 },
-                                color: const Color.fromRGBO(48, 81, 118, 1),
+                                color: theme.GirafColors.loginButtonColor,
                               ),
                             ),
                           )

--- a/lib/screens/show_activity_screen.dart
+++ b/lib/screens/show_activity_screen.dart
@@ -161,7 +161,7 @@ class ShowActivityScreen extends StatelessWidget {
             child: Container(
                 decoration: BoxDecoration(
                     border: Border.all(
-                        color: theme.GirafColors.borderColor,
+                        color: theme.GirafColors.blueBorderColor,
                         width: 0.25)),
                 child: StreamBuilder<ActivityModel>(
                     stream: _activityBloc.activityModelStream,

--- a/lib/screens/show_activity_screen.dart
+++ b/lib/screens/show_activity_screen.dart
@@ -14,6 +14,8 @@ import 'package:weekplanner/widgets/giraf_activity_time_picker_dialog.dart';
 import 'package:weekplanner/widgets/giraf_app_bar_widget.dart';
 import 'package:weekplanner/widgets/giraf_button_widget.dart';
 import 'package:weekplanner/widgets/giraf_confirm_dialog.dart';
+import '../style/custom_color.dart' as theme;
+
 
 /// Screen to show information about an activity, and change the state of it.
 class ShowActivityScreen extends StatelessWidget {
@@ -159,7 +161,7 @@ class ShowActivityScreen extends StatelessWidget {
             child: Container(
                 decoration: BoxDecoration(
                     border: Border.all(
-                        color: const Color.fromRGBO(35, 35, 35, 1.0),
+                        color: theme.GirafColors.borderColor,
                         width: 0.25)),
                 child: StreamBuilder<ActivityModel>(
                     stream: _activityBloc.activityModelStream,

--- a/lib/screens/weekplan_screen.dart
+++ b/lib/screens/weekplan_screen.dart
@@ -22,9 +22,8 @@ import 'package:weekplanner/widgets/bottom_app_bar_button_widget.dart';
 import 'package:weekplanner/widgets/giraf_app_bar_widget.dart';
 import 'package:weekplanner/widgets/giraf_confirm_dialog.dart';
 import 'package:weekplanner/widgets/giraf_copy_activities_dialog.dart';
+import '../style/custom_color.dart' as theme;
 
-/// Color of the add buttons
-const Color buttonColor = Color(0xA0FFFFFF);
 
 /// <summary>
 /// The WeekplanScreen is used to display a week
@@ -132,8 +131,8 @@ class WeekplanScreen extends StatelessWidget {
                         2 / 3
                       ],
                           colors: <Color>[
-                        Color.fromRGBO(254, 215, 108, 1),
-                        Color.fromRGBO(253, 187, 85, 1),
+                        theme.GirafColors.appBarYellow,
+                        theme.GirafColors.appBarOrange,
                       ])),
                   child: Row(
                     mainAxisSize: MainAxisSize.min,
@@ -231,20 +230,20 @@ class WeekplanScreen extends StatelessWidget {
   }
 
   Row _buildWeeks(WeekModel weekModel, BuildContext context) {
-    const List<int> weekColors = <int>[
-      0xFF08A045,
-      0xFF540D6E,
-      0xFFF77F00,
-      0xFF004777,
-      0xFFF9C80E,
-      0xFFDB2B39,
-      0xFFFFFFFF
+    const List<Color> weekColors = <Color>[
+      theme.GirafColors.mondayColor,
+      theme.GirafColors.tuesdayColor,
+      theme.GirafColors.wednesdayColor,
+      theme.GirafColors.thursdayColor,
+      theme.GirafColors.fridayColor,
+      theme.GirafColors.saturdayColor,
+      theme.GirafColors.sundayColor
     ];
     final List<Widget> weekDays = <Widget>[];
     for (int i = 0; i < weekModel.days.length; i++) {
       weekDays.add(Expanded(
           child: Card(
-              color: Color(weekColors[i]),
+              color: weekColors[i],
               child: _day(weekModel.days[i], context))));
     }
     return Row(children: weekDays);
@@ -269,7 +268,7 @@ class WeekplanScreen extends StatelessWidget {
                       child: RaisedButton(
                           key: const Key('AddActivityButton'),
                           child: Image.asset('assets/icons/add.png'),
-                          color: buttonColor,
+                          color: theme.GirafColors.buttonColor,
                           onPressed: () async {
                             final PictogramModel newActivity =
                                 await Routes.push(context, PictogramSearch());
@@ -389,7 +388,7 @@ class WeekplanScreen extends StatelessWidget {
         return const AspectRatio(
           aspectRatio: 1,
           child: Card(
-            color: Color.fromRGBO(200, 200, 200, 0.5),
+            color: theme.GirafColors.dragShadow,
             child: ListTile(),
           ),
         );
@@ -583,7 +582,7 @@ class WeekplanScreen extends StatelessWidget {
 
     return Card(
       key: Key(translation),
-      color: buttonColor,
+      color: theme.GirafColors.buttonColor,
       child: ListTile(
         contentPadding: const EdgeInsets.all(0.0), // Sets padding in cards
         title: AutoSizeText(

--- a/lib/screens/weekplan_selector_screen.dart
+++ b/lib/screens/weekplan_selector_screen.dart
@@ -15,6 +15,7 @@ import 'package:weekplanner/widgets/bottom_app_bar_button_widget.dart';
 import 'package:weekplanner/widgets/giraf_app_bar_widget.dart';
 import 'package:weekplanner/widgets/giraf_button_widget.dart';
 import 'package:weekplanner/widgets/giraf_confirm_dialog.dart';
+import '../style/custom_color.dart' as theme;
 
 /// Screen to select a weekplan for a given user
 class WeekplanSelectorScreen extends StatelessWidget {
@@ -225,8 +226,8 @@ class WeekplanSelectorScreen extends StatelessWidget {
                     2 / 3
                   ],
                       colors: <Color>[
-                    Color.fromRGBO(254, 215, 108, 1),
-                    Color.fromRGBO(253, 187, 85, 1),
+                    theme.GirafColors.appBarYellow,
+                    theme.GirafColors.appBarOrange,
                   ])),
               child: Row(
                 mainAxisSize: MainAxisSize.min,

--- a/lib/style/custom_color.dart
+++ b/lib/style/custom_color.dart
@@ -1,9 +1,22 @@
 import 'package:flutter/material.dart';
 
+/// Custom colors for the GIRAP project. New colors can be added here.
 class GirafColors {
   GirafColors._();
 
-  static const Color transparentGrey = Color.fromRGBO(170, 170, 170, 1);
+  static const Color loginFieldText = Color.fromRGBO(170, 170, 170, 1);
   static const Color loginButtonColor = Color.fromRGBO(48, 81, 118, 1);
+  static const Color buttonColor = Color(0xA0FFFFFF);
+  static const Color appBarYellow = Color.fromRGBO(254, 215, 108, 1);
+  static const Color appBarOrange = Color.fromRGBO(253, 187, 85, 1);
 
+  static const Color mondayColor = Color(0xFF08A045);
+  static const Color tuesdayColor = Color(0xFF540D6E);
+  static const Color wednesdayColor = Color(0xFFF77F00);
+  static const Color thursdayColor = Color(0xFF004777);
+  static const Color fridayColor = Color(0xFFF9C80E);
+  static const Color saturdayColor= Color(0xFFDB2B39);
+  static const Color sundayColor = Color(0xFFFFFFFF);
+
+  static const Color dragShadow = Color.fromRGBO(200, 200, 200, 0.5);
 }

--- a/lib/style/custom_color.dart
+++ b/lib/style/custom_color.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-/// Custom colors for the GIRAP project. New colors can be added here.
+/// Custom colors for the GIRAF project. New colors can be added here.
 class GirafColors {
   GirafColors._();
 
@@ -64,4 +64,9 @@ class GirafColors {
   /// Color of checkbox
   static const Color checkboxColor = Color.fromARGB(255, 255, 157, 0);
 
+  /// Color of button used in pop up
+  static const Color dialogButton = Color.fromRGBO(255, 157, 0, 100);
+
+  /// Color of the border used in the activity widget
+  static const Color blueBorderColor = Color.fromRGBO(35, 35, 35, 1);
 }

--- a/lib/style/custom_color.dart
+++ b/lib/style/custom_color.dart
@@ -55,4 +55,13 @@ class GirafColors {
   /// Border color for button disabled gradient
   static const Color gradientDisabledBorder = Color(0xA68A6E00);
 
+  /// Color for the loading spinner
+  static const Color loadingColor = Color.fromRGBO(255, 157, 0, 0.8);
+
+  /// Color for the notification widget
+  static const Color transparentBlack = Color.fromRGBO(0, 0, 0, 1);
+
+  /// Color of checkbox
+  static const Color checkboxColor = Color.fromARGB(255, 255, 157, 0);
+
 }

--- a/lib/style/custom_color.dart
+++ b/lib/style/custom_color.dart
@@ -32,4 +32,7 @@ class GirafColors {
 
   /// Color of the shadows box when trying to move a card in the week planner
   static const Color dragShadow = Color.fromRGBO(200, 200, 200, 0.5);
+
+  /// Dark blue color for border
+  static const Color borderColor =Color.fromRGBO(35, 35, 35, 1.0);
 }

--- a/lib/style/custom_color.dart
+++ b/lib/style/custom_color.dart
@@ -4,19 +4,32 @@ import 'package:flutter/material.dart';
 class GirafColors {
   GirafColors._();
 
+  /// Color for the text in the login field
   static const Color loginFieldText = Color.fromRGBO(170, 170, 170, 1);
+  /// Color for the login button
   static const Color loginButtonColor = Color.fromRGBO(48, 81, 118, 1);
+  /// Color for the buttons
   static const Color buttonColor = Color(0xA0FFFFFF);
+  /// The top color of the appbar
   static const Color appBarYellow = Color.fromRGBO(254, 215, 108, 1);
+  /// The bottom color of the appbar
   static const Color appBarOrange = Color.fromRGBO(253, 187, 85, 1);
 
+  /// Color of monday in the week planner
   static const Color mondayColor = Color(0xFF08A045);
+  /// Color of tuesday in the week planner
   static const Color tuesdayColor = Color(0xFF540D6E);
+  /// Color of wednesday in the week planner
   static const Color wednesdayColor = Color(0xFFF77F00);
+  /// Color of thursday in the week planner
   static const Color thursdayColor = Color(0xFF004777);
+  /// Color of friday in the week planner
   static const Color fridayColor = Color(0xFFF9C80E);
+  /// Color of saturday in the week planner
   static const Color saturdayColor= Color(0xFFDB2B39);
+  /// Color of sunday in the week planner
   static const Color sundayColor = Color(0xFFFFFFFF);
 
+  /// Color of the shadows box when trying to move a card in the week planner
   static const Color dragShadow = Color.fromRGBO(200, 200, 200, 0.5);
 }

--- a/lib/style/custom_color.dart
+++ b/lib/style/custom_color.dart
@@ -32,4 +32,27 @@ class GirafColors {
 
   /// Color of the shadows box when trying to move a card in the week planner
   static const Color dragShadow = Color.fromRGBO(200, 200, 200, 0.5);
+
+  /// Color of transparent dark grey border
+  static const Color transparentDarkGrey = Color.fromRGBO(112, 112, 112, 1);
+
+  /// Yellow color for button default gradient
+  static const Color gradientDefaultYellow = Color(0xFFFFCD59);
+  /// Orange color for button default gradient
+  static const Color gradientDefaultOrange = Color(0xFFFF9D00);
+  /// Border color for button default gradient
+  static const Color gradientDefaultBorder = Color(0xFF8A6E00);
+  /// Yellow color for button pressed gradient
+  static const Color gradientPressedYellow = Color(0xFFD4AD2F);
+  /// Orange color for button pressed gradient
+  static const Color gradientPressedOrange = Color(0xFFFF9D00);
+  /// Border color for button pressed gradient
+  static const Color gradientPressedBorder = Color(0xFF493700);
+  /// Yellow color for button disabled gradient
+  static const Color gradientDisabledYellow = Color(0x46FFCD59);
+  /// Orange color for button disabled gradient
+  static const Color gradientDisabledOrange = Color(0xA6FF9D00);
+  /// Border color for button disabled gradient
+  static const Color gradientDisabledBorder = Color(0xA68A6E00);
+
 }

--- a/lib/style/custom_color.dart
+++ b/lib/style/custom_color.dart
@@ -1,0 +1,9 @@
+import 'package:flutter/material.dart';
+
+class GirafColors {
+  GirafColors._();
+
+  static const Color transparentGrey = Color.fromRGBO(170, 170, 170, 1);
+  static const Color loginButtonColor = Color.fromRGBO(48, 81, 118, 1);
+
+}

--- a/lib/widgets/giraf_activity_time_picker_dialog.dart
+++ b/lib/widgets/giraf_activity_time_picker_dialog.dart
@@ -6,6 +6,7 @@ import 'package:weekplanner/routes.dart';
 import 'package:weekplanner/widgets/giraf_button_widget.dart';
 import 'package:weekplanner/widgets/giraf_notify_dialog.dart';
 import 'package:weekplanner/widgets/giraf_title_header.dart';
+import '../style/custom_color.dart' as theme;
 
 /// The acitivty time picker dialog is a dialog, asking for a duration input.
 /// The duration should be inserted in the textfield, and the user can either
@@ -38,7 +39,7 @@ class GirafActivityTimerPickerDialog extends StatelessWidget {
         contentPadding: const EdgeInsets.all(0.0),
         titlePadding: const EdgeInsets.all(0.0),
         shape: Border.all(
-            color: const Color.fromRGBO(112, 112, 112, 1), width: 5.0),
+            color: theme.GirafColors.transparentDarkGrey, width: 5.0),
         title: const Center(
             child: GirafTitleHeader(
               title: 'Vælg tid for aktivitet',

--- a/lib/widgets/giraf_button_widget.dart
+++ b/lib/widgets/giraf_button_widget.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:rxdart/rxdart.dart';
+import '../style/custom_color.dart' as theme;
 
 /// A button for the Giraf application.
 class GirafButton extends StatefulWidget {
@@ -66,23 +67,26 @@ class _GirafButtonState extends State<GirafButton> {
   }
 
   static const Gradient _gradientDefault = LinearGradient(
-      colors: <Color>[Color(0xFFFFCD59), Color(0xFFFF9D00)],
+      colors: <Color>[theme.GirafColors.gradientDefaultYellow,
+        theme.GirafColors.gradientDefaultOrange],
       begin: Alignment(0.0, -1.0),
       end: Alignment(0.0, 1.0));
 
   static const Gradient _gradientPressed = LinearGradient(
-      colors: <Color>[Color(0xFFD4AD2F), Color(0xFFFF9D00)],
+      colors: <Color>[theme.GirafColors.gradientPressedYellow,
+        theme.GirafColors.gradientPressedOrange],
       begin: Alignment(0.0, -1.0),
       end: Alignment(0.0, 1.0));
 
   static const Gradient _gradientDisabled = LinearGradient(
-      colors: <Color>[Color(0x46FFCD59), Color(0xA6FF9D00)],
+      colors: <Color>[theme.GirafColors.gradientDisabledYellow,
+        theme.GirafColors.gradientDisabledOrange],
       begin: Alignment(0.0, -1.0),
       end: Alignment(0.0, 1.0));
 
-  static const Color _borderDefault = Color(0xFF8A6E00);
-  static const Color _borderPressed = Color(0xFF493700);
-  static const Color _borderDisabled = Color(0xA68A6E00);
+  static const Color _borderDefault = theme.GirafColors.gradientDefaultBorder;
+  static const Color _borderPressed = theme.GirafColors.gradientPressedBorder;
+  static const Color _borderDisabled = theme.GirafColors.gradientDisabledBorder;
 
   bool _isPressed;
   bool _isEnabled;

--- a/lib/widgets/giraf_confirm_dialog.dart
+++ b/lib/widgets/giraf_confirm_dialog.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:weekplanner/routes.dart';
 import 'package:weekplanner/widgets/giraf_button_widget.dart';
 import 'package:weekplanner/widgets/giraf_title_header.dart';
+import '../style/custom_color.dart' as theme;
 
 ///A dialog widget presented to the user to confirm an action, such as
 ///logging out or deleting a weekplan. The dialog consists of a title,
@@ -41,7 +42,7 @@ class GirafConfirmDialog extends StatelessWidget {
       contentPadding: const EdgeInsets.all(0.0),
       titlePadding: const EdgeInsets.all(0.0),
       shape:
-          Border.all(color: const Color.fromRGBO(112, 112, 112, 1), width: 5.0),
+          Border.all(color: theme.GirafColors.transparentDarkGrey, width: 5.0),
       title: Center(
           child: GirafTitleHeader(
         title: title,

--- a/lib/widgets/giraf_copy_activities_dialog.dart
+++ b/lib/widgets/giraf_copy_activities_dialog.dart
@@ -4,6 +4,7 @@ import 'package:weekplanner/blocs/copy_activities_bloc.dart';
 import 'package:weekplanner/di.dart';
 import 'package:weekplanner/widgets/copy_dialog_buttons_widget.dart';
 import 'package:weekplanner/widgets/giraf_title_header.dart';
+import '../style/custom_color.dart' as theme;
 
 /// A dialog widget presented to the user to confirm an action based on
 /// a list of checkboxes presented in the dialog. The dialog consists of a
@@ -40,16 +41,13 @@ class GirafCopyActivitiesDialog extends StatelessWidget {
   /// the method to call when the confirmation button is pressed
   final void Function(List<bool>, BuildContext) confirmOnPressed;
 
-  /// color of checkbox
-  static const Color checkboxColor = Color.fromARGB(255, 255, 157, 0);
-
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
       contentPadding: const EdgeInsets.all(0.0),
       titlePadding: const EdgeInsets.all(0.0),
       shape:
-          Border.all(color: const Color.fromRGBO(112, 112, 112, 1), width: 5.0),
+          Border.all(color: theme.GirafColors.transparentDarkGrey, width: 5.0),
       title: Center(
           child: GirafTitleHeader(
         title: title,
@@ -146,7 +144,7 @@ class GirafCopyActivitiesDialog extends StatelessWidget {
           copyActivitiesBloc.toggleCheckboxState(weekday.index),
       title: Text(checkboxTitle),
       controlAffinity: ListTileControlAffinity.trailing,
-      activeColor: checkboxColor,
+      activeColor: theme.GirafColors.checkboxColor,
     );
   }
 }

--- a/lib/widgets/giraf_notify_dialog.dart
+++ b/lib/widgets/giraf_notify_dialog.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:weekplanner/routes.dart';
 import 'package:weekplanner/widgets/giraf_button_widget.dart';
 import 'package:weekplanner/widgets/giraf_title_header.dart';
+import '../style/custom_color.dart' as theme;
 
 /// An AlertDialog for notifications, with a title and description as input.
 /// The only action that the dialog can do is pressing okay, as the
@@ -29,7 +30,7 @@ class GirafNotifyDialog extends StatelessWidget implements PreferredSizeWidget {
       contentPadding: const EdgeInsets.all(0.0),
       titlePadding: const EdgeInsets.all(0.0),
       shape:
-      Border.all(color: const Color.fromRGBO(112, 112, 112, 1), width: 5.0),
+      Border.all(color: theme.GirafColors.transparentDarkGrey, width: 5.0),
       title: Center(
           child: GirafTitleHeader(
             title: title,
@@ -63,7 +64,7 @@ class GirafNotifyDialog extends StatelessWidget implements PreferredSizeWidget {
                     text: 'Okay',
                     icon: const ImageIcon(
                       AssetImage('assets/icons/accept.png'),
-                      color: Color.fromRGBO(0, 0, 0, 1),),
+                      color: theme.GirafColors.transparentBlack,),
                     onPressed: (){Routes.pop(context);},
                   )
                 ],

--- a/lib/widgets/giraf_title_header.dart
+++ b/lib/widgets/giraf_title_header.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../style/custom_color.dart' as theme;
 
 /// The GirafDialogHeader is to be used at the title location of widgets
 class GirafTitleHeader extends StatelessWidget implements PreferredSizeWidget {
@@ -34,8 +35,8 @@ class GirafTitleHeader extends StatelessWidget implements PreferredSizeWidget {
                   0.66
                 ],
                     colors: <Color>[
-                  Color.fromRGBO(254, 215, 108, 1),
-                  Color.fromRGBO(253, 187, 85, 1),
+                  theme.GirafColors.appBarYellow,
+                  theme.GirafColors.appBarOrange,
                 ])),
           ),
         ),

--- a/lib/widgets/loading_spinner_widget.dart
+++ b/lib/widgets/loading_spinner_widget.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
+import '../style/custom_color.dart' as theme;
 
 /// Callback is optional and gives functionality that allows a
 /// method to be called after the timeout
@@ -37,7 +38,7 @@ class LoadingSpinnerWidget extends StatelessWidget {
           scale: 2,
           child: const CircularProgressIndicator(
             valueColor: AlwaysStoppedAnimation<Color>(
-                Color.fromRGBO(255, 157, 0, 0.8)),
+                theme.GirafColors.loadingColor),
           )),
     );
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: WeekPlanner for GIRAF
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: ">=2.7.0 <3.0.0"
 
 dependencies:
   shared_preferences: ^0.5.1+1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: WeekPlanner for GIRAF
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: ">=2.1.0 <3.0.0"
 
 dependencies:
   shared_preferences: ^0.5.1+1


### PR DESCRIPTION
fixes #228 

We have created a folder with the stylesheet (.dart) containing all the colours using RGB or hex, which can be imported for the standardised colours. All places where there are custom colours have been replaced with references to this stylesheet. The sheet only contains custom colours, where future custom colours can be added. 