### PR TITLE
Feature 317

### DIFF
--- a/lib/blocs/weekplan_bloc.dart
+++ b/lib/blocs/weekplan_bloc.dart
@@ -28,8 +28,8 @@ class WeekplanBloc extends BlocBase {
       _activityPlaceholderVisible.stream;
 
   /// Checks if there are no selected activities
-  Stream<bool> get markedActivitiesNotEmpty =>
-      _markedActivitiesNotEmpty();
+  Stream<bool> get atLeastOneActivityMarked =>
+      _atLeastOneActivityMarked();
 
   /// The API
   final Api _api;
@@ -234,7 +234,7 @@ class WeekplanBloc extends BlocBase {
     });
   }
 
-  Observable<bool> _markedActivitiesNotEmpty(){
+  Observable<bool> _atLeastOneActivityMarked(){
     return _markedActivities.map((List<ActivityModel> activities) =>
     activities.isNotEmpty);
   }

--- a/lib/blocs/weekplan_bloc.dart
+++ b/lib/blocs/weekplan_bloc.dart
@@ -27,6 +27,10 @@ class WeekplanBloc extends BlocBase {
   Stream<bool> get activityPlaceholderVisible =>
       _activityPlaceholderVisible.stream;
 
+  /// Checks if there are no selected activities
+  Stream<bool> get markedActivitiesNotEmpty =>
+      _markedActivitiesNotEmptyStream();
+
   /// The API
   final Api _api;
   final BehaviorSubject<bool> _editMode = BehaviorSubject<bool>.seeded(false);
@@ -230,8 +234,7 @@ class WeekplanBloc extends BlocBase {
     });
   }
 
-  /// Checks if there are no selected activities
-  Observable<bool> activitiesNotEmptyStream(){
+  Observable<bool> _markedActivitiesNotEmptyStream(){
     return _markedActivities.map((List<ActivityModel> activities) =>
     activities.isNotEmpty);
   }

--- a/lib/blocs/weekplan_bloc.dart
+++ b/lib/blocs/weekplan_bloc.dart
@@ -29,7 +29,7 @@ class WeekplanBloc extends BlocBase {
 
   /// Checks if there are no selected activities
   Stream<bool> get markedActivitiesNotEmpty =>
-      _markedActivitiesNotEmptyStream();
+      _markedActivitiesNotEmpty();
 
   /// The API
   final Api _api;
@@ -234,7 +234,7 @@ class WeekplanBloc extends BlocBase {
     });
   }
 
-  Observable<bool> _markedActivitiesNotEmptyStream(){
+  Observable<bool> _markedActivitiesNotEmpty(){
     return _markedActivities.map((List<ActivityModel> activities) =>
     activities.isNotEmpty);
   }

--- a/lib/blocs/weekplan_bloc.dart
+++ b/lib/blocs/weekplan_bloc.dart
@@ -230,6 +230,12 @@ class WeekplanBloc extends BlocBase {
     });
   }
 
+  /// Checks if there are no selected activities
+  Observable<bool> activitiesNotEmptyStream(){
+    return _markedActivities.map((List<ActivityModel> activities) =>
+    activities.isNotEmpty);
+  }
+
   @override
   void dispose() {
     _userWeek.close();

--- a/lib/screens/weekplan_screen.dart
+++ b/lib/screens/weekplan_screen.dart
@@ -145,7 +145,7 @@ class WeekplanScreen extends StatelessWidget {
                           assetPath: 'assets/icons/cancel.png',
                           isEnabled: false,
                           isEnabledStream: _weekplanBloc.
-                                                    activitiesNotEmptyStream(),
+                                                  markedActivitiesNotEmpty,
                           dialogFunction: _buildCancelDialog),
                       BottomAppBarButton(
                           buttonText: 'Kopier',
@@ -153,7 +153,7 @@ class WeekplanScreen extends StatelessWidget {
                           assetPath: 'assets/icons/copy.png',
                           isEnabled: false,
                           isEnabledStream: _weekplanBloc.
-                                                    activitiesNotEmptyStream(),
+                                                markedActivitiesNotEmpty,
                           dialogFunction: _buildCopyDialog),
                       BottomAppBarButton(
                           buttonText: 'Slet',
@@ -161,7 +161,7 @@ class WeekplanScreen extends StatelessWidget {
                           assetPath: 'assets/icons/delete.png',
                           isEnabled: false,
                           isEnabledStream: _weekplanBloc.
-                                                    activitiesNotEmptyStream(),
+                                                markedActivitiesNotEmpty,
                           dialogFunction: _buildRemoveDialog)
                     ],
                   )))

--- a/lib/screens/weekplan_screen.dart
+++ b/lib/screens/weekplan_screen.dart
@@ -143,16 +143,25 @@ class WeekplanScreen extends StatelessWidget {
                           buttonText: 'Aflys',
                           buttonKey: 'CancelActivtiesButton',
                           assetPath: 'assets/icons/cancel.png',
+                          isEnabled: false,
+                          isEnabledStream: _weekplanBloc.
+                                                    activitiesNotEmptyStream(),
                           dialogFunction: _buildCancelDialog),
                       BottomAppBarButton(
                           buttonText: 'Kopier',
                           buttonKey: 'CopyActivtiesButton',
                           assetPath: 'assets/icons/copy.png',
+                          isEnabled: false,
+                          isEnabledStream: _weekplanBloc.
+                                                    activitiesNotEmptyStream(),
                           dialogFunction: _buildCopyDialog),
                       BottomAppBarButton(
                           buttonText: 'Slet',
                           buttonKey: 'DeleteActivtiesButton',
                           assetPath: 'assets/icons/delete.png',
+                          isEnabled: false,
+                          isEnabledStream: _weekplanBloc.
+                                                    activitiesNotEmptyStream(),
                           dialogFunction: _buildRemoveDialog)
                     ],
                   )))

--- a/lib/screens/weekplan_screen.dart
+++ b/lib/screens/weekplan_screen.dart
@@ -145,7 +145,7 @@ class WeekplanScreen extends StatelessWidget {
                           assetPath: 'assets/icons/cancel.png',
                           isEnabled: false,
                           isEnabledStream: _weekplanBloc.
-                                                  markedActivitiesNotEmpty,
+                                                  atLeastOneActivityMarked,
                           dialogFunction: _buildCancelDialog),
                       BottomAppBarButton(
                           buttonText: 'Kopier',
@@ -153,7 +153,7 @@ class WeekplanScreen extends StatelessWidget {
                           assetPath: 'assets/icons/copy.png',
                           isEnabled: false,
                           isEnabledStream: _weekplanBloc.
-                                                markedActivitiesNotEmpty,
+                                                atLeastOneActivityMarked,
                           dialogFunction: _buildCopyDialog),
                       BottomAppBarButton(
                           buttonText: 'Slet',
@@ -161,7 +161,7 @@ class WeekplanScreen extends StatelessWidget {
                           assetPath: 'assets/icons/delete.png',
                           isEnabled: false,
                           isEnabledStream: _weekplanBloc.
-                                                markedActivitiesNotEmpty,
+                                                atLeastOneActivityMarked,
                           dialogFunction: _buildRemoveDialog)
                     ],
                   )))

--- a/lib/widgets/bottom_app_bar_button_widget.dart
+++ b/lib/widgets/bottom_app_bar_button_widget.dart
@@ -28,15 +28,12 @@ class BottomAppBarButton extends StatelessWidget {
   /// Function to handle when the button is pressed. 
   final Function dialogFunction;
 
-  /// Determines whether the button is enabled or disabled by default. If
-  /// isEnabledStream is also supplied, the latest emitted item from the stream
-  /// will determine whether the button is enabled. If the stream emits a null
-  /// value, isEnabled will be used instead.
+  /// Determines whether the button is enabled or disabled by default. If no
+  /// isEnabledStream is supplied.
   final bool isEnabled;
 
   /// A stream which tells whether the button should be enabled or disabled.
-  /// If the stream emits a null value, the value of isEnabled will be used
-  /// instead.
+  /// If the stream emits a null value, isEnabled will be used instead.
   final Observable<bool> isEnabledStream;
 
   @override

--- a/lib/widgets/bottom_app_bar_button_widget.dart
+++ b/lib/widgets/bottom_app_bar_button_widget.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/cupertino.dart';
+import 'package:rxdart/rxdart.dart';
 import 'package:weekplanner/widgets/giraf_button_widget.dart';
 
 /// Creates a button in the ButtomAppBar.
@@ -11,6 +12,8 @@ class BottomAppBarButton extends StatelessWidget {
     @required this.buttonKey,
     @required this.assetPath,
     @required this.dialogFunction,
+    this.isEnabled  = true,
+    this.isEnabledStream,
   }) : super(key: key);
 
   /// Text to be dispayed on the button.
@@ -25,6 +28,17 @@ class BottomAppBarButton extends StatelessWidget {
   /// Function to handle when the button is pressed. 
   final Function dialogFunction;
 
+  /// Determines whether the button is enabled or disabled by default. If
+  /// isEnabledStream is also supplied, the latest emitted item from the stream
+  /// will determine whether the button is enabled. If the stream emits a null
+  /// value, isEnabled will be used instead.
+  final bool isEnabled;
+
+  /// A stream which tells whether the button should be enabled or disabled.
+  /// If the stream emits a null value, the value of isEnabled will be used
+  /// instead.
+  final Observable<bool> isEnabledStream;
+
   @override
   Widget build(BuildContext context) {
     return Padding(
@@ -36,6 +50,8 @@ class BottomAppBarButton extends StatelessWidget {
         onPressed: () {
           dialogFunction(context);
         },
+        isEnabled: isEnabled,
+        isEnabledStream: isEnabledStream,
       ),
     );
   }

--- a/test/blocs/weekplan_bloc_test.dart
+++ b/test/blocs/weekplan_bloc_test.dart
@@ -567,17 +567,17 @@ void main() {
     weekplanBloc.loadWeek(week, user);
   }));
 
-  test('Testing markedActivitiesNotEmpty returns false when '
+  test('Testing atLeastOneActivityMarked returns false when '
       'no activities are marked', async((DoneFn done) {
 
-    // Listening to the markedActivitiesNotEmpty stream to check it is empty
+    // Listening to the atLeastOneActivityMarked stream to check it is empty
     weekplanBloc.atLeastOneActivityMarked.listen((bool result){
        expect(result, isFalse);
        done();
     });
   }));
 
-  test('Testing markedActivitiesNotEmpty returns true when an activity is '
+  test('Testing atLeastOneActivityMarked returns true when an activity is '
       'marked', async((DoneFn done) {
 
     // Creating the activity that will be added
@@ -586,7 +586,7 @@ void main() {
 
     weekplanBloc.addMarkedActivity(testActivity);
 
-    // Listening to the markedActivitiesNotEmpty stream to check it is filled
+    // Listening to the atLeastOneActivityMarked stream to check it is filled
     weekplanBloc.atLeastOneActivityMarked.listen((bool result){
       expect(result, isTrue);
       done();

--- a/test/blocs/weekplan_bloc_test.dart
+++ b/test/blocs/weekplan_bloc_test.dart
@@ -571,7 +571,7 @@ void main() {
       'no activities are marked', async((DoneFn done) {
 
     // Listening to the markedActivitiesNotEmpty stream to check it is empty
-    weekplanBloc.markedActivitiesNotEmpty.listen((bool result){
+    weekplanBloc.atLeastOneActivityMarked.listen((bool result){
        expect(result, isFalse);
        done();
     });
@@ -587,7 +587,7 @@ void main() {
     weekplanBloc.addMarkedActivity(testActivity);
 
     // Listening to the markedActivitiesNotEmpty stream to check it is filled
-    weekplanBloc.markedActivitiesNotEmpty.listen((bool result){
+    weekplanBloc.atLeastOneActivityMarked.listen((bool result){
       expect(result, isTrue);
       done();
     });

--- a/test/blocs/weekplan_bloc_test.dart
+++ b/test/blocs/weekplan_bloc_test.dart
@@ -97,7 +97,8 @@ void main() {
         id: 1,
         isChoiceBoard: null,
         order: null,
-        state: null);
+        state: null
+    );
 
     weekplanBloc.markedActivities
         .skip(1)
@@ -564,5 +565,31 @@ void main() {
     });
 
     weekplanBloc.loadWeek(week, user);
+  }));
+
+  test('Testing markedActivitiesNotEmpty returns false when '
+      'no activities are marked', async((DoneFn done) {
+
+    // Listening to the markedActivitiesNotEmpty stream to check it is empty
+    weekplanBloc.markedActivitiesNotEmpty.listen((bool result){
+       expect(result, isFalse);
+       done();
+    });
+  }));
+
+  test('Testing markedActivitiesNotEmpty returns true when an activity is '
+      'marked', async((DoneFn done) {
+
+    // Creating the activity that will be added
+    final ActivityModel testActivity = ActivityModel(
+        id: 1, pictogram: null, order: 0, state: null, isChoiceBoard: false);
+
+    weekplanBloc.addMarkedActivity(testActivity);
+
+    // Listening to the markedActivitiesNotEmpty stream to check it is filled
+    weekplanBloc.markedActivitiesNotEmpty.listen((bool result){
+      expect(result, isTrue);
+      done();
+    });
   }));
 }

--- a/test/widgets/giraf_button_widget_test.dart
+++ b/test/widgets/giraf_button_widget_test.dart
@@ -82,4 +82,6 @@ void main() {
     });
     await done.future;
   });
+
+
 }

--- a/test/widgets/giraf_button_widget_test.dart
+++ b/test/widgets/giraf_button_widget_test.dart
@@ -82,6 +82,4 @@ void main() {
     });
     await done.future;
   });
-
-
 }


### PR DESCRIPTION
fixes #317 

The 'delete', 'cancel', and 'copy' on the weekplan screen are now disabled when no activities are selected. By agreement with the PO group we did this instead of displaying an error message. 
