### PR TITLE
fixes_305

### DIFF
--- a/lib/screens/weekplan_selector_screen.dart
+++ b/lib/screens/weekplan_selector_screen.dart
@@ -97,7 +97,6 @@ class WeekplanSelectorScreen extends StatelessWidget {
 
     if (isMarked) {
       return Container(
-          key: const Key('isSelectedKey'),
           decoration:
               BoxDecoration(border: Border.all(color: Colors.black, width: 15)),
           child: _buildWeekplanCard(context, weekplan, bloc));

--- a/test/screens/weekplan_selector_screen_test.dart
+++ b/test/screens/weekplan_selector_screen_test.dart
@@ -242,7 +242,7 @@ void main() {
     expect(bloc.getMarkedWeekModels().contains(weekModel2), false);
   });
 
-  testWidgets('Marking activity and marking it again unmarks it',
+  testWidgets('Clicking a marked activity should unmark it',
   (WidgetTester tester) async {
     await tester
         .pumpWidget(MaterialApp(home: WeekplanSelectorScreen(mockUser)));

--- a/test/screens/weekplan_selector_screen_test.dart
+++ b/test/screens/weekplan_selector_screen_test.dart
@@ -175,14 +175,19 @@ void main() {
         .pumpWidget(MaterialApp(home: WeekplanSelectorScreen(mockUser)));
     await tester.pumpAndSettle();
 
-    expect(find.text('weekModel1'), findsOneWidget);
+    expect(find.byKey(Key(weekModel1.name)), findsOneWidget);
+    // Before we mark the week plan weekModel1 we check that it
+    // is in fact not marked
+    expect(bloc.getMarkedWeekModels().contains(weekModel1), false);
 
     await tester.tap(find.byTooltip('Rediger'));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(Key(weekModel1.name)));
     await tester.pumpAndSettle();
 
-    expect(find.byKey(const Key('isSelectedKey')), findsOneWidget);
+    // After we have marked the week plan weekModel1 we check that it
+    // is in fact marked
+    expect(bloc.getMarkedWeekModels().contains(weekModel1), true);
   });
 
   testWidgets('Marking a activity and deleting removes it',
@@ -214,7 +219,36 @@ void main() {
         .pumpWidget(MaterialApp(home: WeekplanSelectorScreen(mockUser)));
     await tester.pumpAndSettle();
 
-    expect(find.text('weekModel1'), findsOneWidget);
+    expect(find.byKey(Key(weekModel1.name)), findsOneWidget);
+
+    await tester.tap(find.byTooltip('Rediger'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(Key(weekModel1.name)));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(Key(weekModel2.name)));
+    await tester.pumpAndSettle();
+
+    // Checks that the two marked week model are in fact marked
+    expect(bloc.getMarkedWeekModels().contains(weekModel1), true);
+    expect(bloc.getMarkedWeekModels().contains(weekModel2), true);
+
+    await tester.tap(find.byTooltip('Rediger'));
+    await tester.pumpAndSettle();
+
+    // Checks that after the "Rediger"-button has been pressed, the
+    // week plans are not marked any more
+    expect(bloc.getMarkedWeekModels().contains(weekModel1), false);
+    expect(bloc.getMarkedWeekModels().contains(weekModel2), false);
+  });
+
+  testWidgets('Marking activity and marking it again unmarks it',
+  (WidgetTester tester) async {
+    await tester
+        .pumpWidget(MaterialApp(home: WeekplanSelectorScreen(mockUser)));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(Key(weekModel1.name)), findsOneWidget);
 
     await tester.tap(find.byTooltip('Rediger'));
     await tester.pumpAndSettle();
@@ -222,16 +256,14 @@ void main() {
     await tester.tap(find.byKey(Key(weekModel1.name)));
     await tester.pumpAndSettle();
 
-    expect(find.byKey(const Key('isSelectedKey')), findsOneWidget);
+    // Checks that the marked week model is in fact marked
+    expect(bloc.getMarkedWeekModels().contains(weekModel1), true);
 
-    await tester.tap(find.byKey(Key(weekModel2.name)));
+    await tester.tap(find.byKey(Key(weekModel1.name)));
     await tester.pumpAndSettle();
 
-    expect(find.byKey(const Key('isSelectedKey')), findsNWidgets(2));
-
-    await tester.tap(find.byTooltip('Rediger'));
-    await tester.pumpAndSettle();
-
-    expect(find.byKey(const Key('isSelectedKey')), findsNothing);
+    // Checks that after marking/tapping the week plan again, the
+    // week plan are not marked any more
+    expect(bloc.getMarkedWeekModels().contains(weekModel1), false);
   });
 }


### PR DESCRIPTION
Fixes #305  

Fixed bug by removing duplicate keys for container widgets. Each time a week plan was marked the
key for the specific week plan was set to 'isSelectedKey'. This resulted in all week plans
having the same key ('isSelectedKey') when marking multiple, which is invalid and threw an exception in the flutter library.