### PR TITLE
Fixes 310

### DIFF
--- a/lib/blocs/edit_weekplan_bloc.dart
+++ b/lib/blocs/edit_weekplan_bloc.dart
@@ -3,9 +3,7 @@ import 'dart:async';
 import 'package:api_client/api/api.dart';
 import 'package:api_client/models/username_model.dart';
 import 'package:api_client/models/week_model.dart';
-import 'package:api_client/models/week_name_model.dart';
 import 'package:flutter/cupertino.dart';
-import 'package:rxdart/rxdart.dart';
 import 'package:weekplanner/blocs/new_weekplan_bloc.dart';
 import 'package:weekplanner/blocs/weekplan_selector_bloc.dart';
 

--- a/lib/blocs/edit_weekplan_bloc.dart
+++ b/lib/blocs/edit_weekplan_bloc.dart
@@ -1,9 +1,8 @@
 import 'dart:async';
-
+import 'package:flutter/material.dart';
 import 'package:api_client/api/api.dart';
 import 'package:api_client/models/username_model.dart';
 import 'package:api_client/models/week_model.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:weekplanner/blocs/new_weekplan_bloc.dart';
 import 'package:weekplanner/blocs/weekplan_selector_bloc.dart';
 

--- a/lib/blocs/new_weekplan_bloc.dart
+++ b/lib/blocs/new_weekplan_bloc.dart
@@ -143,8 +143,8 @@ class NewWeekplanBloc extends BlocBase {
     await for (List<WeekNameModel> existingPlans
         in _weekplanSelectorBloc.weekNameModels.take(1)) {
       for (WeekNameModel existingPlan in existingPlans) {
-        if (existingPlan.weekYear == _weekNumber &&
-            existingPlan.weekNumber == _year) {
+        if (existingPlan.weekYear == _year &&
+            existingPlan.weekNumber == _weekNumber) {
           overwrite =
               await _displayOverwriteDialog(context, _weekNumber, _year);
         }

--- a/lib/blocs/new_weekplan_bloc.dart
+++ b/lib/blocs/new_weekplan_bloc.dart
@@ -5,6 +5,7 @@ import 'package:api_client/models/enums/weekday_enum.dart';
 import 'package:api_client/models/pictogram_model.dart';
 import 'package:api_client/models/username_model.dart';
 import 'package:api_client/models/week_model.dart';
+import 'package:api_client/models/week_name_model.dart';
 import 'package:api_client/models/weekday_model.dart';
 import 'package:flutter/material.dart';
 import 'package:rxdart/rxdart.dart';
@@ -21,20 +22,29 @@ class NewWeekplanBloc extends BlocBase {
   /// This is done with the method [initialize].
   NewWeekplanBloc(this.weekApi);
 
-  @protected /// This is used to access the weekModel in the database
+  /// This is used to access the weekModel in the database
+  @protected
   final Api weekApi;
 
-  @protected /// This field is used to get the userId. Accessed in
+  /// This field is used to get the userId. Accessed in
   /// [edit_weekplan_bloc].
+  @protected
   UsernameModel weekUser;
 
-  @protected /// This field controls the title input field
+  /// This field controls the title input field
+  @protected
   final BehaviorSubject<String> titleController = BehaviorSubject<String>();
-  @protected  /// This field controls the year no input field
+
+  /// This field controls the year no input field
+  @protected
   final BehaviorSubject<String> yearController = BehaviorSubject<String>();
-  @protected /// This field controls the week no input field
+
+  /// This field controls the week no input field
+  @protected
   final BehaviorSubject<String> weekNoController = BehaviorSubject<String>();
-  @protected  /// This field controls the pictogram input field
+
+  /// This field controls the pictogram input field
+  @protected
   final BehaviorSubject<PictogramModel> thumbnailController =
       BehaviorSubject<PictogramModel>();
 
@@ -46,6 +56,15 @@ class NewWeekplanBloc extends BlocBase {
 
   /// Handles when the entered week number is changed.
   Sink<String> get onWeekNumberChanged => weekNoController.sink;
+
+  /// Emits a [WeekNameModel] when it has a title, year, and week.
+  /// If any input is invalid, emits null.
+  Stream<WeekNameModel> get newWeekPlan => Observable.combineLatest4(
+      allInputsAreValidStream,
+      titleController.stream,
+      yearController.stream,
+      weekNoController.stream,
+      _combineWeekNameModel);
 
   /// Handles when the thumbnail is changed.
   Sink<PictogramModel> get onThumbnailChanged => thumbnailController.sink;
@@ -126,6 +145,15 @@ class NewWeekplanBloc extends BlocBase {
     yearController.sink.add(null);
     weekNoController.sink.add(null);
     thumbnailController.sink.add(null);
+  }
+
+  WeekNameModel _combineWeekNameModel(
+      bool isValid, String name, String year, String week) {
+    if (!isValid) {
+      return null;
+    }
+    return WeekNameModel(
+        name: name, weekYear: int.parse(year), weekNumber: int.parse(week));
   }
 
   bool _isAllInputValid(

--- a/lib/blocs/new_weekplan_bloc.dart
+++ b/lib/blocs/new_weekplan_bloc.dart
@@ -288,4 +288,3 @@ class NewWeekplanBloc extends BlocBase {
   }
 }
 
-class Context {}

--- a/lib/blocs/weekplan_selector_bloc.dart
+++ b/lib/blocs/weekplan_selector_bloc.dart
@@ -53,8 +53,9 @@ class WeekplansBloc extends BlocBase {
     _user = user;
     _addWeekplan = addWeekplan;
     weekNameModels.listen(getAllWeekInfo);
-    _api.week.getNames(_user.id).listen(_weekNameModelsList.add,
-        onError: (Object exception) => getAllWeekInfo(null));
+    _api.week.getNames(_user.id).listen((List<WeekNameModel> weekNames) {
+      _weekNameModelsList.add(weekNames);
+    }, onError: (Object exception) => getAllWeekInfo(null));
   }
 
   /// Gets all the information for a [Weekmodel].
@@ -79,7 +80,7 @@ class WeekplansBloc extends BlocBase {
           .listen((WeekModel results) {
         weekModels.add(results);
         weekModels.sort((WeekModel a, WeekModel b) {
-          if (a.name == 'Tilføj ugeplan'){
+          if (a.name == 'Tilføj ugeplan') {
             return -1;
           }
           if (a.weekYear == b.weekYear) {

--- a/lib/bootstrap.dart
+++ b/lib/bootstrap.dart
@@ -38,7 +38,7 @@ class Bootstrap {
       return WeekplanBloc(i.getDependency<Api>());
     });
 
-    di.registerDependency((Injector i) {
+    di.registerSingleton<WeekplansBloc>((Injector i) {
       return WeekplansBloc(i.getDependency<Api>());
     });
 

--- a/lib/bootstrap.dart
+++ b/lib/bootstrap.dart
@@ -61,7 +61,7 @@ class Bootstrap {
       return NewWeekplanBloc(i.getDependency<Api>());
     });
 
-    di.registerSingleton<EditWeekplanBloc>((Injector i) {
+    di.registerDependency<EditWeekplanBloc>((Injector i) {
       return EditWeekplanBloc(i.getDependency<Api>());
     });
 

--- a/lib/screens/edit_weekplan_screen.dart
+++ b/lib/screens/edit_weekplan_screen.dart
@@ -19,7 +19,8 @@ class EditWeekPlanScreen extends StatelessWidget {
     @required UsernameModel user,
     @required this.weekModel,
     @required this.selectorBloc,
-  }) : _bloc = di.getDependency<EditWeekplanBloc>(), _weekPlans = selectorBloc.weekNameModels  {
+  })  : _bloc = di.getDependency<EditWeekplanBloc>(),
+        _weekPlans = selectorBloc.weekNameModels {
     _bloc.initializeEditBloc(user, weekModel);
   }
 
@@ -40,8 +41,7 @@ class EditWeekPlanScreen extends StatelessWidget {
       text: 'Gem ændringer',
       isEnabled: false,
       isEnabledStream: _bloc.allInputsAreValidStream,
-      onPressed: ()
-      {
+      onPressed: () {
         {
           _weekPlans.take(1).listen((List<WeekNameModel> weekPlans) {
             _bloc.newWeekPlan.take(1).listen((WeekNameModel newWeekPlan) {
@@ -61,7 +61,8 @@ class EditWeekPlanScreen extends StatelessWidget {
                         return GirafConfirmDialog(
                           key: const Key('OverwriteDialogKey'),
                           title: 'Overskriv ugeplan',
-                          description: 'Ugeplanen (uge: ${newWeekPlan.weekNumber}'
+                          description:
+                              'Ugeplanen (uge: ${newWeekPlan.weekNumber}'
                               ', år: ${newWeekPlan.weekYear}) eksisterer '
                               'allerede. Vil du overskrive denne ugeplan?',
                           confirmButtonText: 'Okay',

--- a/lib/screens/edit_weekplan_screen.dart
+++ b/lib/screens/edit_weekplan_screen.dart
@@ -33,6 +33,7 @@ class EditWeekPlanScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     final GirafButton editButton = GirafButton(
       icon: const ImageIcon(AssetImage('assets/icons/edit.png')),
+      key: const Key('EditWeekPlanSaveBtnKey'),
       text: 'Gem ændringer',
       isEnabled: false,
       isEnabledStream: _bloc.allInputsAreValidStream,

--- a/lib/screens/edit_weekplan_screen.dart
+++ b/lib/screens/edit_weekplan_screen.dart
@@ -1,6 +1,5 @@
 import 'package:api_client/models/username_model.dart';
 import 'package:api_client/models/week_model.dart';
-import 'package:api_client/models/week_name_model.dart';
 import 'package:flutter/material.dart';
 import 'package:weekplanner/blocs/edit_weekplan_bloc.dart';
 import 'package:weekplanner/blocs/weekplan_selector_bloc.dart';
@@ -8,7 +7,6 @@ import 'package:weekplanner/di.dart';
 import 'package:weekplanner/routes.dart';
 import 'package:weekplanner/widgets/giraf_app_bar_widget.dart';
 import 'package:weekplanner/widgets/giraf_button_widget.dart';
-import 'package:weekplanner/widgets/giraf_confirm_dialog.dart';
 import 'package:weekplanner/widgets/input_fields_weekplan.dart';
 
 ///This screen is called when you edit a week plan
@@ -18,7 +16,6 @@ class EditWeekPlanScreen extends StatelessWidget {
   EditWeekPlanScreen({
     @required UsernameModel user,
     @required this.weekModel,
-    @required this.selectorBloc,
   }) : _bloc = di.getDependency<EditWeekplanBloc>() {
     _bloc.initializeEditBloc(user, weekModel);
   }
@@ -28,7 +25,7 @@ class EditWeekPlanScreen extends StatelessWidget {
 
   /// This bloc is the bloc from the week plan selector screen it is needed in
   /// in order to delete the week plan
-  final WeekplansBloc selectorBloc;
+  final WeekplansBloc selectorBloc = di.getDependency<WeekplansBloc>();
 
   final EditWeekplanBloc _bloc;
 

--- a/lib/screens/edit_weekplan_screen.dart
+++ b/lib/screens/edit_weekplan_screen.dart
@@ -50,7 +50,9 @@ class EditWeekPlanScreen extends StatelessWidget {
 
             for (WeekNameModel existingPlan in weekPlans) {
               if (existingPlan.weekYear == newWeekPlan.weekYear &&
-                  existingPlan.weekNumber == newWeekPlan.weekNumber) {
+                  existingPlan.weekNumber == newWeekPlan.weekNumber &&
+                  weekModel.weekNumber != newWeekPlan.weekNumber &&
+                  weekModel.weekYear != newWeekPlan.weekYear) {
                 // Show dialog
                 showDialog<Center>(
                     context: context,

--- a/lib/screens/edit_weekplan_screen.dart
+++ b/lib/screens/edit_weekplan_screen.dart
@@ -39,59 +39,15 @@ class EditWeekPlanScreen extends StatelessWidget {
       text: 'Gem ændringer',
       isEnabled: false,
       isEnabledStream: _bloc.allInputsAreValidStream,
-      onPressed: () {
-        selectorBloc.weekNameModels
-            .take(1)
-            .listen((List<WeekNameModel> weekPlans) {
-          _bloc.newWeekPlan.take(1).listen((WeekNameModel newWeekPlan) {
-            if (newWeekPlan == null) {
-              return;
-            }
+      onPressed: () async {
+        final WeekModel result = await _bloc.editWeekPlan(
+            screenContext: context,
+            oldWeekModel: weekModel,
+            selectorBloc: selectorBloc);
 
-            for (WeekNameModel existingPlan in weekPlans) {
-              if (existingPlan.weekYear == newWeekPlan.weekYear &&
-                  existingPlan.weekNumber == newWeekPlan.weekNumber &&
-                  weekModel.weekNumber != newWeekPlan.weekNumber &&
-                  weekModel.weekYear != newWeekPlan.weekYear) {
-                // Show dialog
-                showDialog<Center>(
-                    context: context,
-                    barrierDismissible: false,
-                    builder: (BuildContext dialogContext) {
-                      // A confirmation dialog is shown to stop the timer.
-                      return GirafConfirmDialog(
-                        key: const Key('OverwriteDialogKey'),
-                        title: 'Overskriv ugeplan',
-                        description: 'Ugeplanen (uge: ${newWeekPlan.weekNumber}'
-                            ', år: ${newWeekPlan.weekYear}) eksisterer '
-                            'allerede. Vil du overskrive denne ugeplan?',
-                        confirmButtonText: 'Okay',
-                        confirmButtonIcon: const ImageIcon(
-                            AssetImage('assets/icons/accept.png')),
-                        confirmOnPressed: () {
-                          _bloc
-                              .editWeekPlan(weekModel, selectorBloc)
-                              .listen((WeekModel response) {
-                            if (response != null) {
-                              Routes.pop(dialogContext);
-                              Routes.pop<WeekModel>(context, response);
-                            }
-                          });
-                        },
-                      );
-                    });
-                return;
-              }
-            }
-            _bloc
-                .editWeekPlan(weekModel, selectorBloc)
-                .listen((WeekModel response) {
-              if (response != null) {
-                Routes.pop<WeekModel>(context, response);
-              }
-            });
-          });
-        });
+        if (result != null) {
+          Routes.pop<WeekModel>(context, result);
+        }
       },
     );
 

--- a/lib/screens/new_weekplan_screen.dart
+++ b/lib/screens/new_weekplan_screen.dart
@@ -15,13 +15,10 @@ import 'package:weekplanner/widgets/input_fields_weekplan.dart';
 class NewWeekplanScreen extends StatelessWidget {
   /// Screen for creating a new weekplan.
   /// Requires a [UsernameModel] to be able to save the new weekplan.
-  NewWeekplanScreen(UsernameModel user, {@required this.selectorBloc})
+  NewWeekplanScreen(UsernameModel user)
       : _bloc = di.getDependency<NewWeekplanBloc>() {
     _bloc.initialize(user);
   }
-
-  /// Week plan selector bloc. Needed to get list of existing week plans.
-  final WeekplansBloc selectorBloc;
 
   final NewWeekplanBloc _bloc;
 
@@ -33,54 +30,11 @@ class NewWeekplanScreen extends StatelessWidget {
       text: 'Gem ugeplan',
       isEnabled: false,
       isEnabledStream: _bloc.allInputsAreValidStream,
-      onPressed: () {
-        selectorBloc.weekNameModels
-            .take(1)
-            .listen((List<WeekNameModel> weekPlans) {
-          _bloc.newWeekPlan.take(1).listen((WeekNameModel newWeekPlan) {
-            if (newWeekPlan == null) {
-              return;
-            }
-
-            for (WeekNameModel existingPlan in weekPlans) {
-              if (existingPlan.weekYear == newWeekPlan.weekYear &&
-                  existingPlan.weekNumber == newWeekPlan.weekNumber) {
-                // Show dialog
-                showDialog<Center>(
-                    context: context,
-                    barrierDismissible: false,
-                    builder: (BuildContext dialogContext) {
-                      // A confirmation dialog is shown to stop the timer.
-                      return GirafConfirmDialog(
-                        key: const Key('OverwriteEditDialogKey'),
-                        title: 'Overskriv ugeplan',
-                        description: 'Ugeplanen (uge: ${newWeekPlan.weekNumber}'
-                            ', år: ${newWeekPlan.weekYear}) eksisterer '
-                            'allerede. Vil du overskrive denne ugeplan?',
-                        confirmButtonText: 'Okay',
-                        confirmButtonIcon: const ImageIcon(
-                            AssetImage('assets/icons/accept.png')),
-                        confirmOnPressed: () {
-                          _bloc.saveWeekplan().listen((WeekModel response) {
-                            if (response != null) {
-                              Routes.pop(dialogContext);
-                              Routes.pop<WeekModel>(context, response);
-                            }
-                          });
-                        },
-                      );
-                    });
-                return;
-              }
-            }
-            _bloc.saveWeekplan().listen((WeekModel response) {
-              if (response != null) {
-                Routes.pop<WeekModel>(context, response);
-              }
-            });
-          });
-        });
-      },
+      onPressed: () => _bloc.saveWeekplan(context).then(
+        (WeekModel newWeekPlan) {
+          Routes.pop<WeekModel>(context, newWeekPlan);
+        },
+      ),
     );
 
     return Scaffold(

--- a/lib/screens/new_weekplan_screen.dart
+++ b/lib/screens/new_weekplan_screen.dart
@@ -3,6 +3,7 @@ import 'package:api_client/models/week_model.dart';
 import 'package:api_client/models/week_name_model.dart';
 import 'package:flutter/material.dart';
 import 'package:weekplanner/blocs/new_weekplan_bloc.dart';
+import 'package:weekplanner/blocs/weekplan_selector_bloc.dart';
 import 'package:weekplanner/di.dart';
 import 'package:weekplanner/routes.dart';
 import 'package:weekplanner/widgets/giraf_app_bar_widget.dart';
@@ -14,15 +15,15 @@ import 'package:weekplanner/widgets/input_fields_weekplan.dart';
 class NewWeekplanScreen extends StatelessWidget {
   /// Screen for creating a new weekplan.
   /// Requires a [UsernameModel] to be able to save the new weekplan.
-  NewWeekplanScreen(UsernameModel user,
-      {@required Stream<List<WeekNameModel>> weekPlans})
-      : _bloc = di.getDependency<NewWeekplanBloc>(),
-        _weekPlans = weekPlans {
+  NewWeekplanScreen(UsernameModel user, {@required this.selectorBloc})
+      : _bloc = di.getDependency<NewWeekplanBloc>() {
     _bloc.initialize(user);
   }
 
+  /// Week plan selector bloc. Needed to get list of existing week plans.
+  final WeekplansBloc selectorBloc;
+
   final NewWeekplanBloc _bloc;
-  final Stream<List<WeekNameModel>> _weekPlans;
 
   @override
   Widget build(BuildContext context) {
@@ -33,7 +34,9 @@ class NewWeekplanScreen extends StatelessWidget {
       isEnabled: false,
       isEnabledStream: _bloc.allInputsAreValidStream,
       onPressed: () {
-        _weekPlans.take(1).listen((List<WeekNameModel> weekPlans) {
+        selectorBloc.weekNameModels
+            .take(1)
+            .listen((List<WeekNameModel> weekPlans) {
           _bloc.newWeekPlan.take(1).listen((WeekNameModel newWeekPlan) {
             if (newWeekPlan == null) {
               return;

--- a/lib/screens/new_weekplan_screen.dart
+++ b/lib/screens/new_weekplan_screen.dart
@@ -35,10 +35,9 @@ class NewWeekplanScreen extends StatelessWidget {
       isEnabled: false,
       isEnabledStream: _bloc.allInputsAreValidStream,
       onPressed: () {
-        _weekPlans.listen((List<WeekNameModel> weekPlans) {
-          _bloc.newWeekPlan.listen((WeekNameModel newWeekPlan) {
+        _weekPlans.take(1).listen((List<WeekNameModel> weekPlans) {
+          _bloc.newWeekPlan.take(1).listen((WeekNameModel newWeekPlan) {
             if (newWeekPlan == null) {
-              // Show error.
               return;
             }
 
@@ -49,12 +48,12 @@ class NewWeekplanScreen extends StatelessWidget {
                 showDialog<Center>(
                     context: context,
                     barrierDismissible: false,
-                    builder: (BuildContext context) {
+                    builder: (BuildContext dialogContext) {
                       // A confirmation dialog is shown to stop the timer.
                       return GirafConfirmDialog(
                         key: const Key('OverwriteDialogKey'),
-                        title: 'Overskriv',
-                        description: 'Vil du gemme?',
+                        title: 'Overskriv ugeplan',
+                        description: 'Ugeplan',
                         confirmButtonText: 'Okay',
                         confirmButtonIcon: const ImageIcon(
                             AssetImage('assets/icons/accept.png')),

--- a/lib/screens/new_weekplan_screen.dart
+++ b/lib/screens/new_weekplan_screen.dart
@@ -6,6 +6,7 @@ import 'package:weekplanner/di.dart';
 import 'package:weekplanner/routes.dart';
 import 'package:weekplanner/widgets/giraf_app_bar_widget.dart';
 import 'package:weekplanner/widgets/giraf_button_widget.dart';
+import 'package:weekplanner/widgets/giraf_confirm_dialog.dart';
 import 'package:weekplanner/widgets/input_fields_weekplan.dart';
 
 /// Screen for creating a new weekplan.
@@ -28,11 +29,27 @@ class NewWeekplanScreen extends StatelessWidget {
       isEnabled: false,
       isEnabledStream: _bloc.allInputsAreValidStream,
       onPressed: () {
-        _bloc.saveWeekplan().listen((WeekModel response) {
-          if (response != null) {
-            Routes.pop<WeekModel>(context, response);
-          }
-        });
+        showDialog<Center>(
+            context: context,
+            barrierDismissible: false,
+            builder: (BuildContext context) {
+              // A confirmation dialog is shown to stop the timer.
+              return GirafConfirmDialog(
+                key: const Key('OverwriteDialogKey'),
+                title: 'Overskriv',
+                description: 'Vil du gemme?',
+                confirmButtonText: 'Okay',
+                confirmButtonIcon:
+                    const ImageIcon(AssetImage('assets/icons/accept.png')),
+                confirmOnPressed: () {
+                  _bloc.saveWeekplan().listen((WeekModel response) {
+                    if (response != null) {
+                      Routes.pop<WeekModel>(context, response);
+                    }
+                  });
+                },
+              );
+            });
       },
     );
 

--- a/lib/screens/new_weekplan_screen.dart
+++ b/lib/screens/new_weekplan_screen.dart
@@ -51,8 +51,8 @@ class NewWeekplanScreen extends StatelessWidget {
                       return GirafConfirmDialog(
                         key: const Key('OverwriteDialogKey'),
                         title: 'Overskriv ugeplan',
-                        description: 'Ugeplanen (år: ${newWeekPlan.weekYear}'
-                            ', uge: ${newWeekPlan.weekNumber}) eksisterer  '
+                        description: 'Ugeplanen (uge: ${newWeekPlan.weekNumber}'
+                            ', år: ${newWeekPlan.weekYear}) eksisterer '
                             'allerede. Vil du overskrive denne ugeplan?',
                         confirmButtonText: 'Okay',
                         confirmButtonIcon: const ImageIcon(

--- a/lib/screens/new_weekplan_screen.dart
+++ b/lib/screens/new_weekplan_screen.dart
@@ -15,9 +15,7 @@ class NewWeekplanScreen extends StatelessWidget {
   /// Screen for creating a new weekplan.
   /// Requires a [UsernameModel] to be able to save the new weekplan.
   NewWeekplanScreen(UsernameModel user,
-      {@required Stream<List<WeekNameModel>> weekPlans})
-      : _bloc = di.getDependency<NewWeekplanBloc>(),
-        _weekPlans = weekPlans {
+      {@required Stream<List<WeekNameModel>> weekPlans}): _bloc = di.getDependency<NewWeekplanBloc>(), _weekPlans = weekPlans {
     _bloc.initialize(user);
   }
 
@@ -39,9 +37,9 @@ class NewWeekplanScreen extends StatelessWidget {
               return;
             }
 
-            for (WeekNameModel exisitingPlan in weekPlans) {
-              if (exisitingPlan.weekYear == newWeekPlan.weekYear &&
-                  exisitingPlan.weekNumber == newWeekPlan.weekNumber) {
+            for (WeekNameModel existingPlan in weekPlans) {
+              if (existingPlan.weekYear == newWeekPlan.weekYear &&
+                  existingPlan.weekNumber == newWeekPlan.weekNumber) {
                 // Show dialog
                 showDialog<Center>(
                     context: context,
@@ -49,7 +47,7 @@ class NewWeekplanScreen extends StatelessWidget {
                     builder: (BuildContext dialogContext) {
                       // A confirmation dialog is shown to stop the timer.
                       return GirafConfirmDialog(
-                        key: const Key('OverwriteDialogKey'),
+                        key: const Key('OverwriteEditDialogKey'),
                         title: 'Overskriv ugeplan',
                         description: 'Ugeplanen (uge: ${newWeekPlan.weekNumber}'
                             ', år: ${newWeekPlan.weekYear}) eksisterer '

--- a/lib/screens/new_weekplan_screen.dart
+++ b/lib/screens/new_weekplan_screen.dart
@@ -13,12 +13,14 @@ import 'package:weekplanner/widgets/input_fields_weekplan.dart';
 class NewWeekplanScreen extends StatelessWidget {
   /// Screen for creating a new weekplan.
   /// Requires a [UsernameModel] to be able to save the new weekplan.
-  NewWeekplanScreen(UsernameModel user)
-      : _bloc = di.getDependency<NewWeekplanBloc>() {
+  NewWeekplanScreen(UsernameModel user, {Stream<List<WeekModel>> weekPlans})
+      : _bloc = di.getDependency<NewWeekplanBloc>(),
+        _weekPlans = weekPlans {
     _bloc.initialize(user);
   }
 
   final NewWeekplanBloc _bloc;
+  final Stream<List<WeekModel>> _weekPlans;
 
   @override
   Widget build(BuildContext context) {
@@ -29,6 +31,11 @@ class NewWeekplanScreen extends StatelessWidget {
       isEnabled: false,
       isEnabledStream: _bloc.allInputsAreValidStream,
       onPressed: () {
+        _weekPlans.listen((List<WeekModel> weekPlans) {
+          // TODO: Move showDialog here.
+          
+        });
+
         showDialog<Center>(
             context: context,
             barrierDismissible: false,

--- a/lib/screens/new_weekplan_screen.dart
+++ b/lib/screens/new_weekplan_screen.dart
@@ -2,9 +2,7 @@ import 'package:api_client/models/username_model.dart';
 import 'package:api_client/models/week_model.dart';
 import 'package:api_client/models/week_name_model.dart';
 import 'package:flutter/material.dart';
-import 'package:rxdart/rxdart.dart';
 import 'package:weekplanner/blocs/new_weekplan_bloc.dart';
-import 'package:weekplanner/blocs/weekplan_selector_bloc.dart';
 import 'package:weekplanner/di.dart';
 import 'package:weekplanner/routes.dart';
 import 'package:weekplanner/widgets/giraf_app_bar_widget.dart';
@@ -54,7 +52,7 @@ class NewWeekplanScreen extends StatelessWidget {
                         key: const Key('OverwriteDialogKey'),
                         title: 'Overskriv ugeplan',
                         description: 'Ugeplanen (år: ${newWeekPlan.weekYear}'
-                            ', uge: ${newWeekPlan.weekNumber}) eksistere '
+                            ', uge: ${newWeekPlan.weekNumber}) eksisterer  '
                             'allerede. Vil du overskrive denne ugeplan?',
                         confirmButtonText: 'Okay',
                         confirmButtonIcon: const ImageIcon(
@@ -72,7 +70,6 @@ class NewWeekplanScreen extends StatelessWidget {
                 return;
               }
             }
-            
             _bloc.saveWeekplan().listen((WeekModel response) {
               if (response != null) {
                 Routes.pop<WeekModel>(context, response);

--- a/lib/screens/new_weekplan_screen.dart
+++ b/lib/screens/new_weekplan_screen.dart
@@ -60,6 +60,7 @@ class NewWeekplanScreen extends StatelessWidget {
                         confirmOnPressed: () {
                           _bloc.saveWeekplan().listen((WeekModel response) {
                             if (response != null) {
+                              Routes.pop(dialogContext);
                               Routes.pop<WeekModel>(context, response);
                             }
                           });

--- a/lib/screens/new_weekplan_screen.dart
+++ b/lib/screens/new_weekplan_screen.dart
@@ -53,7 +53,9 @@ class NewWeekplanScreen extends StatelessWidget {
                       return GirafConfirmDialog(
                         key: const Key('OverwriteDialogKey'),
                         title: 'Overskriv ugeplan',
-                        description: 'Ugeplan',
+                        description: 'Ugeplanen (år: ${newWeekPlan.weekYear}'
+                            ', uge: ${newWeekPlan.weekNumber}) eksistere '
+                            'allerede. Vil du overskrive denne ugeplan?',
                         confirmButtonText: 'Okay',
                         confirmButtonIcon: const ImageIcon(
                             AssetImage('assets/icons/accept.png')),

--- a/lib/screens/new_weekplan_screen.dart
+++ b/lib/screens/new_weekplan_screen.dart
@@ -30,13 +30,12 @@ class NewWeekplanScreen extends StatelessWidget {
       text: 'Gem ugeplan',
       isEnabled: false,
       isEnabledStream: _bloc.allInputsAreValidStream,
-      onPressed: () => _bloc.saveWeekplan(context).then(
-        (WeekModel newWeekPlan) {
-          if (newWeekPlan != null) {
-            Routes.pop<WeekModel>(context, newWeekPlan);
-          }
-        },
-      ),
+      onPressed: () async {
+        final WeekModel newWeekPlan = await _bloc.saveWeekplan(context);
+        if (newWeekPlan != null) {
+          Routes.pop<WeekModel>(context, newWeekPlan);
+        }
+      },
     );
 
     return Scaffold(

--- a/lib/screens/new_weekplan_screen.dart
+++ b/lib/screens/new_weekplan_screen.dart
@@ -2,6 +2,7 @@ import 'package:api_client/models/username_model.dart';
 import 'package:api_client/models/week_model.dart';
 import 'package:flutter/material.dart';
 import 'package:weekplanner/blocs/new_weekplan_bloc.dart';
+import 'package:weekplanner/blocs/weekplan_selector_bloc.dart';
 import 'package:weekplanner/di.dart';
 import 'package:weekplanner/routes.dart';
 import 'package:weekplanner/widgets/giraf_app_bar_widget.dart';
@@ -13,14 +14,13 @@ import 'package:weekplanner/widgets/input_fields_weekplan.dart';
 class NewWeekplanScreen extends StatelessWidget {
   /// Screen for creating a new weekplan.
   /// Requires a [UsernameModel] to be able to save the new weekplan.
-  NewWeekplanScreen(UsernameModel user, {Stream<List<WeekModel>> weekPlans})
-      : _bloc = di.getDependency<NewWeekplanBloc>(),
-        _weekPlans = weekPlans {
+  NewWeekplanScreen(UsernameModel user)
+      : _bloc = di.getDependency<NewWeekplanBloc>() {
     _bloc.initialize(user);
   }
 
+  final WeekplansBloc _weekplansBloc = di.getDependency<WeekplansBloc>();
   final NewWeekplanBloc _bloc;
-  final Stream<List<WeekModel>> _weekPlans;
 
   @override
   Widget build(BuildContext context) {
@@ -31,9 +31,8 @@ class NewWeekplanScreen extends StatelessWidget {
       isEnabled: false,
       isEnabledStream: _bloc.allInputsAreValidStream,
       onPressed: () {
-        _weekPlans.listen((List<WeekModel> weekPlans) {
+        _weekplansBloc.weekModels.listen((List<WeekModel> weekPlans) {
           // TODO: Move showDialog here.
-          
         });
 
         showDialog<Center>(

--- a/lib/screens/new_weekplan_screen.dart
+++ b/lib/screens/new_weekplan_screen.dart
@@ -1,14 +1,11 @@
 import 'package:api_client/models/username_model.dart';
 import 'package:api_client/models/week_model.dart';
-import 'package:api_client/models/week_name_model.dart';
 import 'package:flutter/material.dart';
 import 'package:weekplanner/blocs/new_weekplan_bloc.dart';
-import 'package:weekplanner/blocs/weekplan_selector_bloc.dart';
 import 'package:weekplanner/di.dart';
 import 'package:weekplanner/routes.dart';
 import 'package:weekplanner/widgets/giraf_app_bar_widget.dart';
 import 'package:weekplanner/widgets/giraf_button_widget.dart';
-import 'package:weekplanner/widgets/giraf_confirm_dialog.dart';
 import 'package:weekplanner/widgets/input_fields_weekplan.dart';
 
 /// Screen for creating a new weekplan.

--- a/lib/screens/new_weekplan_screen.dart
+++ b/lib/screens/new_weekplan_screen.dart
@@ -1,6 +1,8 @@
 import 'package:api_client/models/username_model.dart';
 import 'package:api_client/models/week_model.dart';
+import 'package:api_client/models/week_name_model.dart';
 import 'package:flutter/material.dart';
+import 'package:rxdart/rxdart.dart';
 import 'package:weekplanner/blocs/new_weekplan_bloc.dart';
 import 'package:weekplanner/blocs/weekplan_selector_bloc.dart';
 import 'package:weekplanner/di.dart';
@@ -14,13 +16,15 @@ import 'package:weekplanner/widgets/input_fields_weekplan.dart';
 class NewWeekplanScreen extends StatelessWidget {
   /// Screen for creating a new weekplan.
   /// Requires a [UsernameModel] to be able to save the new weekplan.
-  NewWeekplanScreen(UsernameModel user)
-      : _bloc = di.getDependency<NewWeekplanBloc>() {
+  NewWeekplanScreen(UsernameModel user,
+      {@required Stream<List<WeekNameModel>> weekPlans})
+      : _bloc = di.getDependency<NewWeekplanBloc>(),
+        _weekPlans = weekPlans {
     _bloc.initialize(user);
   }
 
-  final WeekplansBloc _weekplansBloc = di.getDependency<WeekplansBloc>();
   final NewWeekplanBloc _bloc;
+  final Stream<List<WeekNameModel>> _weekPlans;
 
   @override
   Widget build(BuildContext context) {
@@ -31,31 +35,49 @@ class NewWeekplanScreen extends StatelessWidget {
       isEnabled: false,
       isEnabledStream: _bloc.allInputsAreValidStream,
       onPressed: () {
-        _weekplansBloc.weekModels.listen((List<WeekModel> weekPlans) {
-          // TODO: Move showDialog here.
-        });
+        _weekPlans.listen((List<WeekNameModel> weekPlans) {
+          _bloc.newWeekPlan.listen((WeekNameModel newWeekPlan) {
+            if (newWeekPlan == null) {
+              // Show error.
+              return;
+            }
 
-        showDialog<Center>(
-            context: context,
-            barrierDismissible: false,
-            builder: (BuildContext context) {
-              // A confirmation dialog is shown to stop the timer.
-              return GirafConfirmDialog(
-                key: const Key('OverwriteDialogKey'),
-                title: 'Overskriv',
-                description: 'Vil du gemme?',
-                confirmButtonText: 'Okay',
-                confirmButtonIcon:
-                    const ImageIcon(AssetImage('assets/icons/accept.png')),
-                confirmOnPressed: () {
-                  _bloc.saveWeekplan().listen((WeekModel response) {
-                    if (response != null) {
-                      Routes.pop<WeekModel>(context, response);
-                    }
-                  });
-                },
-              );
+            for (WeekNameModel exisitingPlan in weekPlans) {
+              if (exisitingPlan.weekYear == newWeekPlan.weekYear &&
+                  exisitingPlan.weekNumber == newWeekPlan.weekNumber) {
+                // Show dialog
+                showDialog<Center>(
+                    context: context,
+                    barrierDismissible: false,
+                    builder: (BuildContext context) {
+                      // A confirmation dialog is shown to stop the timer.
+                      return GirafConfirmDialog(
+                        key: const Key('OverwriteDialogKey'),
+                        title: 'Overskriv',
+                        description: 'Vil du gemme?',
+                        confirmButtonText: 'Okay',
+                        confirmButtonIcon: const ImageIcon(
+                            AssetImage('assets/icons/accept.png')),
+                        confirmOnPressed: () {
+                          _bloc.saveWeekplan().listen((WeekModel response) {
+                            if (response != null) {
+                              Routes.pop<WeekModel>(context, response);
+                            }
+                          });
+                        },
+                      );
+                    });
+                return;
+              }
+            }
+            
+            _bloc.saveWeekplan().listen((WeekModel response) {
+              if (response != null) {
+                Routes.pop<WeekModel>(context, response);
+              }
             });
+          });
+        });
       },
     );
 

--- a/lib/screens/new_weekplan_screen.dart
+++ b/lib/screens/new_weekplan_screen.dart
@@ -32,7 +32,9 @@ class NewWeekplanScreen extends StatelessWidget {
       isEnabledStream: _bloc.allInputsAreValidStream,
       onPressed: () => _bloc.saveWeekplan(context).then(
         (WeekModel newWeekPlan) {
-          Routes.pop<WeekModel>(context, newWeekPlan);
+          if (newWeekPlan != null) {
+            Routes.pop<WeekModel>(context, newWeekPlan);
+          }
         },
       ),
     );

--- a/lib/screens/new_weekplan_screen.dart
+++ b/lib/screens/new_weekplan_screen.dart
@@ -15,7 +15,9 @@ class NewWeekplanScreen extends StatelessWidget {
   /// Screen for creating a new weekplan.
   /// Requires a [UsernameModel] to be able to save the new weekplan.
   NewWeekplanScreen(UsernameModel user,
-      {@required Stream<List<WeekNameModel>> weekPlans}): _bloc = di.getDependency<NewWeekplanBloc>(), _weekPlans = weekPlans {
+      {@required Stream<List<WeekNameModel>> weekPlans})
+      : _bloc = di.getDependency<NewWeekplanBloc>(),
+        _weekPlans = weekPlans {
     _bloc.initialize(user);
   }
 

--- a/lib/screens/weekplan_selector_screen.dart
+++ b/lib/screens/weekplan_selector_screen.dart
@@ -259,7 +259,6 @@ class WeekplanSelectorScreen extends StatelessWidget {
       EditWeekPlanScreen(
         user: _user,
         weekModel: _weekBloc.getMarkedWeekModels()[0],
-        selectorBloc: _weekBloc,
       ),
     ).then((WeekModel newWeek) => _weekBloc.load(_user, true));
     _weekBloc.toggleEditMode();

--- a/lib/screens/weekplan_selector_screen.dart
+++ b/lib/screens/weekplan_selector_screen.dart
@@ -181,11 +181,8 @@ class WeekplanSelectorScreen extends StatelessWidget {
     if (!inEditMode) {
       Routes.push<WeekModel>(
         context,
-        NewWeekplanScreen(
-          _user,
-          weekPlans: _weekBloc.weekNameModels,
-        ),
-      ).then((WeekModel newWeek) => _weekBloc.load(_user, true));
+        NewWeekplanScreen(_user, selectorBloc: _weekBloc),
+      ).then((WeekModel newWeekPlan) => _weekBloc.load(_user, true));
     }
   }
 

--- a/lib/screens/weekplan_selector_screen.dart
+++ b/lib/screens/weekplan_selector_screen.dart
@@ -181,10 +181,7 @@ class WeekplanSelectorScreen extends StatelessWidget {
     if (!inEditMode) {
       Routes.push<WeekModel>(
         context,
-        NewWeekplanScreen(
-          _user,
-          weekPlans: _weekBloc.weekModels,
-        ),
+        NewWeekplanScreen(_user),
       ).then((WeekModel newWeek) => _weekBloc.load(_user, true));
     }
   }

--- a/lib/screens/weekplan_selector_screen.dart
+++ b/lib/screens/weekplan_selector_screen.dart
@@ -179,8 +179,13 @@ class WeekplanSelectorScreen extends StatelessWidget {
   /// Handles on tap on a add new weekplan card
   void handleOnTapWeekPlanAdd(bool inEditMode, BuildContext context) {
     if (!inEditMode) {
-      Routes.push<WeekModel>(context, NewWeekplanScreen(_user))
-          .then((WeekModel newWeek) => _weekBloc.load(_user, true));
+      Routes.push<WeekModel>(
+        context,
+        NewWeekplanScreen(
+          _user,
+          weekPlans: _weekBloc.weekModels,
+        ),
+      ).then((WeekModel newWeek) => _weekBloc.load(_user, true));
     }
   }
 

--- a/lib/screens/weekplan_selector_screen.dart
+++ b/lib/screens/weekplan_selector_screen.dart
@@ -181,7 +181,10 @@ class WeekplanSelectorScreen extends StatelessWidget {
     if (!inEditMode) {
       Routes.push<WeekModel>(
         context,
-        NewWeekplanScreen(_user),
+        NewWeekplanScreen(
+          _user,
+          weekPlans: _weekBloc.weekNameModels,
+        ),
       ).then((WeekModel newWeek) => _weekBloc.load(_user, true));
     }
   }

--- a/lib/screens/weekplan_selector_screen.dart
+++ b/lib/screens/weekplan_selector_screen.dart
@@ -181,7 +181,7 @@ class WeekplanSelectorScreen extends StatelessWidget {
     if (!inEditMode) {
       Routes.push<WeekModel>(
         context,
-        NewWeekplanScreen(_user, selectorBloc: _weekBloc),
+        NewWeekplanScreen(_user),
       ).then((WeekModel newWeekPlan) => _weekBloc.load(_user, true));
     }
   }

--- a/lib/widgets/giraf_confirm_dialog.dart
+++ b/lib/widgets/giraf_confirm_dialog.dart
@@ -84,10 +84,11 @@ class GirafConfirmDialog extends StatelessWidget {
                             AssetImage('assets/icons/cancel.png'),
                             color: Colors.black),
                         onPressed: () {
-                          Routes.pop(context);
                           if (cancelOnPressed != null) {
                             cancelOnPressed();
                           }
+                          
+                          Routes.pop(context);
                         }),
                   ),
                 ),

--- a/lib/widgets/giraf_confirm_dialog.dart
+++ b/lib/widgets/giraf_confirm_dialog.dart
@@ -16,7 +16,8 @@ class GirafConfirmDialog extends StatelessWidget {
       this.description,
       @required this.confirmButtonText,
       @required this.confirmButtonIcon,
-      @required this.confirmOnPressed})
+      @required this.confirmOnPressed,
+      this.cancelOnPressed})
       : super(key: key);
 
   ///title of the dialogBox, displayed in the header of the dialogBox
@@ -34,6 +35,8 @@ class GirafConfirmDialog extends StatelessWidget {
 
   ///the method to call when the confirmation button is pressed
   final VoidCallback confirmOnPressed;
+
+  final VoidCallback cancelOnPressed;
 
   @override
   Widget build(BuildContext context) {
@@ -82,6 +85,9 @@ class GirafConfirmDialog extends StatelessWidget {
                             color: Colors.black),
                         onPressed: () {
                           Routes.pop(context);
+                          if (cancelOnPressed != null) {
+                            cancelOnPressed();
+                          }
                         }),
                   ),
                 ),

--- a/lib/widgets/giraf_confirm_dialog.dart
+++ b/lib/widgets/giraf_confirm_dialog.dart
@@ -36,6 +36,7 @@ class GirafConfirmDialog extends StatelessWidget {
   ///the method to call when the confirmation button is pressed
   final VoidCallback confirmOnPressed;
 
+  ///the method is call when the cancel button is pressed. Optional
   final VoidCallback cancelOnPressed;
 
   @override

--- a/lib/widgets/input_fields_weekplan.dart
+++ b/lib/widgets/input_fields_weekplan.dart
@@ -85,6 +85,7 @@ class InputFieldsWeekPlanState extends State<InputFieldsWeekPlan> {
             stream: widget.bloc.validYearStream,
             builder: (BuildContext context, AsyncSnapshot<bool> snapshot) {
               return TextFormField(
+                key: const Key('NewWeekplanYearField'),
                 keyboardType: TextInputType.number,
                 onChanged: widget.bloc.onYearChanged.add,
                 initialValue: widget.weekModel == null
@@ -108,6 +109,7 @@ class InputFieldsWeekPlanState extends State<InputFieldsWeekPlan> {
             stream: widget.bloc.validWeekNumberStream,
             builder: (BuildContext context, AsyncSnapshot<bool> snapshot) {
               return TextFormField(
+                key: const Key('NewWeekplanWeekField'),
                 keyboardType: TextInputType.number,
                 onChanged: widget.bloc.onWeekNumberChanged.add,
                 initialValue: widget.weekModel == null

--- a/test/blocs/edit_weekplan_bloc_test.dart
+++ b/test/blocs/edit_weekplan_bloc_test.dart
@@ -90,7 +90,7 @@ void main() {
     );
   }));
 
-  test('Should save the weekplan with new weeknumber', async((DoneFn done) {
+  test('Should save the weekplan with new week number', async((DoneFn done) {
     bloc.onTitleChanged.add('Week');
     bloc.onYearChanged.add('2019');
     bloc.onWeekNumberChanged.add('42');

--- a/test/blocs/edit_weekplan_bloc_test.dart
+++ b/test/blocs/edit_weekplan_bloc_test.dart
@@ -59,6 +59,8 @@ void main() {
       },
     );
 
+    when(api.week.delete(mockUser.id, mockWeek.weekYear, mockWeek.weekNumber))
+        .thenAnswer((_) => BehaviorSubject<bool>.seeded(true));
 
     mockWeekplanSelector = WeekplansBloc(api);
     mockWeekplanSelector.load(mockUser);
@@ -70,8 +72,26 @@ void main() {
     bloc.initialize(mockUser);
   });
 
-  test('Should save the new weekplan', async((DoneFn done) {
+  test('Should save the weekplan with new title', async((DoneFn done) {
     bloc.onTitleChanged.add('Ugeplan');
+    bloc.onYearChanged.add('2019');
+    bloc.onWeekNumberChanged.add('1');
+    bloc.onThumbnailChanged.add(mockThumbnail);
+    bloc
+        .editWeekPlan(
+        screenContext: null,
+        oldWeekModel: mockWeek,
+        selectorBloc: mockWeekplanSelector)
+        .then(
+          (WeekModel w) {
+        verify(api.week.update(any, any, any, any));
+        done();
+      },
+    );
+  }));
+
+  test('Should save the weekplan with new weeknumber', async((DoneFn done) {
+    bloc.onTitleChanged.add('Week');
     bloc.onYearChanged.add('2019');
     bloc.onWeekNumberChanged.add('42');
     bloc.onThumbnailChanged.add(mockThumbnail);

--- a/test/blocs/edit_weekplan_bloc_test.dart
+++ b/test/blocs/edit_weekplan_bloc_test.dart
@@ -79,11 +79,11 @@ void main() {
     bloc.onThumbnailChanged.add(mockThumbnail);
     bloc
         .editWeekPlan(
-        screenContext: null,
-        oldWeekModel: mockWeek,
-        selectorBloc: mockWeekplanSelector)
+            screenContext: null,
+            oldWeekModel: mockWeek,
+            selectorBloc: mockWeekplanSelector)
         .then(
-          (WeekModel w) {
+      (WeekModel w) {
         verify(api.week.update(any, any, any, any));
         done();
       },

--- a/test/blocs/edit_weekplan_bloc_test.dart
+++ b/test/blocs/edit_weekplan_bloc_test.dart
@@ -1,0 +1,90 @@
+import 'package:api_client/api/api.dart';
+import 'package:api_client/api/week_api.dart';
+import 'package:api_client/models/pictogram_model.dart';
+import 'package:api_client/models/username_model.dart';
+import 'package:api_client/models/week_model.dart';
+import 'package:api_client/models/week_name_model.dart';
+import 'package:mockito/mockito.dart';
+import 'package:rxdart/rxdart.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:weekplanner/blocs/edit_weekplan_bloc.dart';
+import 'package:async_test/async_test.dart';
+import 'package:weekplanner/blocs/weekplan_selector_bloc.dart';
+import 'package:weekplanner/di.dart';
+
+class MockWeekApi extends Mock implements WeekApi {}
+
+void main() {
+  EditWeekplanBloc bloc;
+  WeekplansBloc mockWeekplanSelector;
+  Api api;
+  final PictogramModel mockThumbnail = PictogramModel(
+      id: 1,
+      lastEdit: null,
+      title: null,
+      accessLevel: null,
+      imageUrl: 'http://any.tld',
+      imageHash: null);
+  final UsernameModel mockUser =
+      UsernameModel(name: 'User', id: '1', role: null);
+  final WeekModel mockWeek = WeekModel(
+      thumbnail: mockThumbnail,
+      days: null,
+      name: 'Week',
+      weekNumber: 1,
+      weekYear: 2019);
+
+  setUp(() {
+    api = Api('any');
+    api.week = MockWeekApi();
+
+    when(api.week.update(any, any, any, any)).thenAnswer((_) {
+      return Observable<WeekModel>.just(mockWeek);
+    });
+
+    when(api.week.getNames(any)).thenAnswer(
+      (_) {
+        return Observable<List<WeekNameModel>>.just(<WeekNameModel>[
+          WeekNameModel(
+              name: mockWeek.name,
+              weekNumber: mockWeek.weekNumber,
+              weekYear: mockWeek.weekYear),
+        ]);
+      },
+    );
+
+    when(api.week.get(any, any, any)).thenAnswer(
+      (_) {
+        return Observable<WeekModel>.just(mockWeek);
+      },
+    );
+
+
+    mockWeekplanSelector = WeekplansBloc(api);
+    mockWeekplanSelector.load(mockUser);
+
+    di.clearAll();
+    di.registerSingleton<WeekplansBloc>((_) => mockWeekplanSelector);
+
+    bloc = EditWeekplanBloc(api);
+    bloc.initialize(mockUser);
+  });
+
+  test('Should save the new weekplan', async((DoneFn done) {
+    bloc.onTitleChanged.add('Ugeplan');
+    bloc.onYearChanged.add('2019');
+    bloc.onWeekNumberChanged.add('42');
+    bloc.onThumbnailChanged.add(mockThumbnail);
+    bloc
+        .editWeekPlan(
+            screenContext: null,
+            oldWeekModel: mockWeek,
+            selectorBloc: mockWeekplanSelector)
+        .then(
+      (WeekModel w) {
+        verify(api.week.update(any, any, any, any));
+        done();
+      },
+    );
+  }));
+}

--- a/test/blocs/new_weekplan_bloc_test.dart
+++ b/test/blocs/new_weekplan_bloc_test.dart
@@ -43,7 +43,7 @@ void main() {
 
     when(api.week.getNames(any)).thenAnswer(
       (_) {
-        return Observable<List<WeekNameModel>>.just([
+        return Observable<List<WeekNameModel>>.just(<WeekNameModel>[
           WeekNameModel(
               name: mockWeek.name,
               weekNumber: mockWeek.weekNumber,

--- a/test/blocs/new_weekplan_bloc_test.dart
+++ b/test/blocs/new_weekplan_bloc_test.dart
@@ -3,27 +3,31 @@ import 'package:api_client/api/week_api.dart';
 import 'package:api_client/models/pictogram_model.dart';
 import 'package:api_client/models/username_model.dart';
 import 'package:api_client/models/week_model.dart';
+import 'package:api_client/models/week_name_model.dart';
 import 'package:mockito/mockito.dart';
 import 'package:rxdart/rxdart.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:weekplanner/blocs/new_weekplan_bloc.dart';
 import 'package:async_test/async_test.dart';
+import 'package:weekplanner/blocs/weekplan_selector_bloc.dart';
+import 'package:weekplanner/di.dart';
 
 class MockWeekApi extends Mock implements WeekApi {}
 
 void main() {
   NewWeekplanBloc bloc;
   Api api;
-  final PictogramModel thumbnail = PictogramModel(
+  final PictogramModel mockThumbnail = PictogramModel(
       id: 1,
       lastEdit: null,
       title: null,
       accessLevel: null,
       imageUrl: 'http://any.tld',
       imageHash: null);
-  final UsernameModel user = UsernameModel(name: 'User', id: '1', role: null);
-  final WeekModel week = WeekModel(
-      thumbnail: thumbnail,
+  final UsernameModel mockUser =
+      UsernameModel(name: 'User', id: '1', role: null);
+  final WeekModel mockWeek = WeekModel(
+      thumbnail: mockThumbnail,
       days: null,
       name: 'Week',
       weekNumber: 1,
@@ -32,23 +36,49 @@ void main() {
   setUp(() {
     api = Api('any');
     api.week = MockWeekApi();
-    bloc = NewWeekplanBloc(api);
-    bloc.initialize(user);
 
     when(api.week.update(any, any, any, any)).thenAnswer((_) {
-      return Observable<WeekModel>.just(week);
+      return Observable<WeekModel>.just(mockWeek);
     });
+
+    when(api.week.getNames(any)).thenAnswer(
+      (_) {
+        return Observable<List<WeekNameModel>>.just([
+          WeekNameModel(
+              name: mockWeek.name,
+              weekNumber: mockWeek.weekNumber,
+              weekYear: mockWeek.weekYear),
+        ]);
+      },
+    );
+
+    when(api.week.get(any, any, any)).thenAnswer(
+      (_) {
+        return Observable<WeekModel>.just(mockWeek);
+      },
+    );
+
+    final WeekplansBloc mockWeekplanSelector = WeekplansBloc(api);
+    mockWeekplanSelector.load(mockUser);
+
+    di.clearAll();
+    di.registerSingleton<WeekplansBloc>((_) => mockWeekplanSelector);
+
+    bloc = NewWeekplanBloc(api);
+    bloc.initialize(mockUser);
   });
 
   test('Should save the new weekplan', async((DoneFn done) {
     bloc.onTitleChanged.add('Ugeplan');
     bloc.onYearChanged.add('2019');
     bloc.onWeekNumberChanged.add('42');
-    bloc.onThumbnailChanged.add(thumbnail);
-    bloc.saveWeekplan(null);
-
-    verify(api.week.update(any, any, any, any));
-    done();
+    bloc.onThumbnailChanged.add(mockThumbnail);
+    bloc.saveWeekplan(null).then(
+      (WeekModel w) {
+        verify(api.week.update(any, any, any, any));
+        done();
+      },
+    );
   }));
 
   test('Should validate title: Ugeplan', async((DoneFn done) {
@@ -176,7 +206,7 @@ void main() {
     bloc.onTitleChanged.add('Ugeplan');
     bloc.onYearChanged.add('2019');
     bloc.onWeekNumberChanged.add('42');
-    bloc.onThumbnailChanged.add(thumbnail);
+    bloc.onThumbnailChanged.add(mockThumbnail);
     bloc.allInputsAreValidStream.listen((bool isValid) {
       expect(isValid, isNotNull);
       expect(isValid, true);
@@ -189,7 +219,7 @@ void main() {
     bloc.onTitleChanged.add('Ugeplan');
     bloc.onYearChanged.add('2019');
     bloc.onWeekNumberChanged.add('-42');
-    bloc.onThumbnailChanged.add(thumbnail);
+    bloc.onThumbnailChanged.add(mockThumbnail);
     bloc.allInputsAreValidStream.listen((bool isValid) {
       expect(isValid, isNotNull);
       expect(isValid, false);
@@ -202,7 +232,7 @@ void main() {
     bloc.onTitleChanged.add('');
     bloc.onYearChanged.add('2019');
     bloc.onWeekNumberChanged.add('42');
-    bloc.onThumbnailChanged.add(thumbnail);
+    bloc.onThumbnailChanged.add(mockThumbnail);
     bloc.allInputsAreValidStream.listen((bool isValid) {
       expect(isValid, isNotNull);
       expect(isValid, false);
@@ -227,7 +257,7 @@ void main() {
     bloc.onTitleChanged.add('Ugeplan');
     bloc.onYearChanged.add('2019');
     bloc.onWeekNumberChanged.add('42');
-    bloc.onThumbnailChanged.add(thumbnail);
+    bloc.onThumbnailChanged.add(mockThumbnail);
     bloc.resetBloc();
     bloc.allInputsAreValidStream.listen((bool isValid) {
       expect(isValid, isNotNull);

--- a/test/blocs/new_weekplan_bloc_test.dart
+++ b/test/blocs/new_weekplan_bloc_test.dart
@@ -45,7 +45,7 @@ void main() {
     bloc.onYearChanged.add('2019');
     bloc.onWeekNumberChanged.add('42');
     bloc.onThumbnailChanged.add(thumbnail);
-    bloc.saveWeekplan();
+    bloc.saveWeekplan(null);
 
     verify(api.week.update(any, any, any, any));
     done();

--- a/test/screens/edit_weekplan_screen_test.dart
+++ b/test/screens/edit_weekplan_screen_test.dart
@@ -1,0 +1,339 @@
+import 'dart:async';
+
+import 'package:api_client/api/api.dart';
+import 'package:api_client/api/pictogram_api.dart';
+import 'package:api_client/api/week_api.dart';
+import 'package:api_client/models/pictogram_model.dart';
+import 'package:api_client/models/username_model.dart';
+import 'package:api_client/models/week_model.dart';
+import 'package:api_client/models/week_name_model.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:rxdart/rxdart.dart';
+import 'package:weekplanner/blocs/auth_bloc.dart';
+import 'package:weekplanner/blocs/edit_weekplan_bloc.dart';
+import 'package:weekplanner/blocs/pictogram_bloc.dart';
+import 'package:weekplanner/blocs/pictogram_image_bloc.dart';
+import 'package:weekplanner/blocs/toolbar_bloc.dart';
+import 'package:weekplanner/blocs/weekplan_selector_bloc.dart';
+import 'package:weekplanner/di.dart';
+import 'package:weekplanner/screens/edit_weekplan_screen.dart';
+import 'package:weekplanner/screens/pictogram_search_screen.dart';
+import 'package:weekplanner/widgets/giraf_app_bar_widget.dart';
+import 'package:weekplanner/widgets/giraf_button_widget.dart';
+import 'package:weekplanner/widgets/giraf_confirm_dialog.dart';
+import 'package:weekplanner/widgets/pictogram_image.dart';
+
+import '../test_image.dart';
+
+class MockEditWeekplanBloc extends EditWeekplanBloc {
+  MockEditWeekplanBloc(this.api) : super(api);
+
+  bool acceptAllInputs = true;
+  Api api;
+
+//  @override
+//  Future<WeekModel> saveWeekplan(BuildContext context) {
+//    final Completer<WeekModel> completer = Completer<WeekModel>();
+//
+//    api.week
+//        .update('123', mockWeek.weekYear, mockWeek.weekNumber, mockWeek)
+//        .listen(completer.complete);
+//
+//    return completer.future;
+//  }
+
+  @override
+  Observable<bool> get validTitleStream =>
+      Observable<bool>.just(acceptAllInputs);
+
+  @override
+  Observable<bool> get validYearStream =>
+      Observable<bool>.just(acceptAllInputs);
+
+  @override
+  Observable<bool> get validWeekNumberStream =>
+      Observable<bool>.just(acceptAllInputs);
+
+  @override
+  Observable<PictogramModel> get thumbnailStream =>
+      Observable<PictogramModel>.just(mockPictogram);
+
+  @override
+  Observable<bool> get allInputsAreValidStream => Observable<bool>.just(true);
+}
+
+class MockWeekApi extends Mock implements WeekApi {}
+
+class MockPictogramApi extends Mock implements PictogramApi {}
+
+final PictogramModel mockPictogram = PictogramModel(
+    id: 1,
+    lastEdit: null,
+    title: null,
+    accessLevel: null,
+    imageUrl: 'http://any.tld',
+    imageHash: null);
+
+final WeekModel mockWeek = WeekModel(
+    thumbnail: mockPictogram,
+    days: null,
+    name: 'Week',
+    weekNumber: 1,
+    weekYear: 2019);
+
+final UsernameModel mockUser =
+    UsernameModel(name: 'test', role: 'test', id: 'test');
+
+void main() {
+  MockEditWeekplanBloc mockBloc;
+  Api api;
+
+  setUp(() {
+    api = Api('any');
+    api.week = MockWeekApi();
+    api.pictogram = MockPictogramApi();
+
+    when(api.pictogram.getImage(mockPictogram.id))
+        .thenAnswer((_) => BehaviorSubject<Image>.seeded(sampleImage));
+
+    when(api.week.update(any, any, any, any)).thenAnswer((_) {
+      return Observable<WeekModel>.just(mockWeek);
+    });
+
+    when(api.week.getNames(any)).thenAnswer(
+      (_) {
+        return Observable<List<WeekNameModel>>.just([
+          WeekNameModel(
+              name: mockWeek.name,
+              weekNumber: mockWeek.weekNumber,
+              weekYear: mockWeek.weekYear),
+        ]);
+      },
+    );
+
+    when(api.week.get(any, any, any)).thenAnswer(
+      (_) {
+        return Observable<WeekModel>.just(mockWeek);
+      },
+    );
+
+    final WeekplansBloc mockWeekplanSelector = WeekplansBloc(api);
+    mockWeekplanSelector.load(mockUser);
+
+    di.clearAll();
+    di.registerSingleton<WeekplansBloc>((_) => mockWeekplanSelector);
+    di.registerDependency<AuthBloc>((_) => AuthBloc(api));
+    di.registerDependency<PictogramBloc>((_) => PictogramBloc(api));
+    di.registerDependency<PictogramImageBloc>((_) => PictogramImageBloc(api));
+    di.registerDependency<ToolbarBloc>((_) => ToolbarBloc());
+    mockBloc = MockEditWeekplanBloc(api);
+    di.registerDependency<EditWeekplanBloc>((_) => mockBloc);
+  });
+
+  group('EditWeekplanScreen rendering', () {
+    testWidgets('Edit week plan screen renders', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: EditWeekPlanScreen(user: mockUser, weekModel: mockWeek),
+        ),
+      );
+    });
+
+    testWidgets('The screen has a GirafAppBar', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: EditWeekPlanScreen(user: mockUser, weekModel: mockWeek),
+        ),
+      );
+
+      expect(
+          find.byWidgetPredicate((Widget widget) =>
+              widget is GirafAppBar && widget.title == 'Rediger ugeplan'),
+          findsOneWidget);
+    });
+  });
+
+  group('EditWeekplanScreen input fields', () {
+    testWidgets('Input fields are rendered', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: EditWeekPlanScreen(user: mockUser, weekModel: mockWeek),
+        ),
+      );
+
+      expect(find.byType(TextField), findsNWidgets(3));
+    });
+
+    testWidgets('Pictograms are rendered', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: EditWeekPlanScreen(user: mockUser, weekModel: mockWeek),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.byType(PictogramImage), findsOneWidget);
+    });
+
+    testWidgets('Buttons are rendered', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: EditWeekPlanScreen(user: mockUser, weekModel: mockWeek),
+        ),
+      );
+
+      expect(find.byType(GirafButton), findsOneWidget);
+    });
+
+    testWidgets('Error text is shown on invalid title input',
+        (WidgetTester tester) async {
+      mockBloc.acceptAllInputs = false;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: EditWeekPlanScreen(user: mockUser, weekModel: mockWeek),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('Titel skal angives'), findsOneWidget);
+    });
+
+    testWidgets('No error text is shown on valid title input',
+        (WidgetTester tester) async {
+      mockBloc.acceptAllInputs = true;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: EditWeekPlanScreen(user: mockUser, weekModel: mockWeek),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('Titel skal angives'), findsNothing);
+    });
+
+    testWidgets('Error text is shown on invalid year input',
+        (WidgetTester tester) async {
+      mockBloc.acceptAllInputs = false;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: EditWeekPlanScreen(user: mockUser, weekModel: mockWeek),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('År skal angives som fire cifre'), findsOneWidget);
+    });
+
+    testWidgets('No error text is shown on valid year input',
+        (WidgetTester tester) async {
+      mockBloc.acceptAllInputs = true;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: EditWeekPlanScreen(user: mockUser, weekModel: mockWeek),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('År skal angives som fire cifre'), findsNothing);
+    });
+
+    testWidgets('Error text is shown on invalid week number input',
+        (WidgetTester tester) async {
+      mockBloc.acceptAllInputs = false;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: EditWeekPlanScreen(user: mockUser, weekModel: mockWeek),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('Ugenummer skal være mellem 1 og 53'), findsOneWidget);
+    });
+    testWidgets('No error text is shown on valid week number input',
+        (WidgetTester tester) async {
+      mockBloc.acceptAllInputs = true;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: EditWeekPlanScreen(user: mockUser, weekModel: mockWeek),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('Ugenummer skal være mellem 1 og 53'), findsNothing);
+    });
+
+    testWidgets('Emojis are blacklisted from title field',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: EditWeekPlanScreen(user: mockUser, weekModel: mockWeek),
+        ),
+      );
+      await tester.enterText(
+          find.byKey(const Key('NewWeekplanTitleField')), '☺♥');
+      await tester.pump();
+
+      expect(find.text('☺♥'), findsNothing);
+    });
+
+    testWidgets('Click on thumbnail redirects to pictogram search screen',
+        (WidgetTester tester) async {
+      mockBloc.acceptAllInputs = true;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: EditWeekPlanScreen(user: mockUser, weekModel: mockWeek),
+        ),
+      );
+      await tester.tap(find.byKey(const Key('NewWeekplanThumbnailKey')));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(PictogramSearch), findsOneWidget);
+    });
+  });
+
+  group('Edit weekplan overwriting', () {
+    testWidgets('Should show expected message when trying to overwrite',
+        (WidgetTester tester) async {
+      final WeekModel editWeekModel = WeekModel(
+          name: mockWeek.name,
+          weekNumber: mockWeek.weekNumber + 1,
+          weekYear: mockWeek.weekYear,
+          days: mockWeek.days,
+          thumbnail: mockWeek.thumbnail);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: EditWeekPlanScreen(user: mockUser, weekModel: editWeekModel),
+        ),
+      );
+      await tester.pump();
+
+      await tester.enterText(
+          find.byKey(const Key('NewWeekplanTitleField')), mockWeek.name);
+      await tester.enterText(find.byKey(const Key('NewWeekplanYearField')),
+          mockWeek.weekYear.toString());
+      await tester.enterText(find.byKey(const Key('NewWeekplanWeekField')),
+          mockWeek.weekNumber.toString());
+      
+      mockBloc.onThumbnailChanged.add(mockWeek.thumbnail);
+
+      final Finder saveButton = find.byWidgetPredicate((Widget widget) =>
+          widget is GirafButton && widget.text == 'Gem ændringer');
+      await tester.tap(saveButton);
+
+      await tester.pumpAndSettle();
+
+      expect(find.byType(GirafConfirmDialog), findsOneWidget);
+      expect(
+          find.text('Ugeplanen (uge: ' +
+              mockWeek.weekNumber.toString() +
+              ', år: ' +
+              mockWeek.weekYear.toString() +
+              ') eksisterer '
+                  'allerede. Vil du overskrive denne ugeplan?'),
+          findsOneWidget);
+    });
+  });
+}

--- a/test/screens/edit_weekplan_screen_test.dart
+++ b/test/screens/edit_weekplan_screen_test.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:api_client/api/api.dart';
 import 'package:api_client/api/pictogram_api.dart';
 import 'package:api_client/api/week_api.dart';
@@ -104,7 +102,7 @@ void main() {
 
     when(api.week.getNames(any)).thenAnswer(
       (_) {
-        return Observable<List<WeekNameModel>>.just([
+        return Observable<List<WeekNameModel>>.just(<WeekNameModel>[
           WeekNameModel(
               name: mockWeek.name,
               weekNumber: mockWeek.weekNumber,

--- a/test/screens/edit_weekplan_screen_test.dart
+++ b/test/screens/edit_weekplan_screen_test.dart
@@ -31,17 +31,6 @@ class MockEditWeekplanBloc extends EditWeekplanBloc {
   bool acceptAllInputs = true;
   Api api;
 
-//  @override
-//  Future<WeekModel> saveWeekplan(BuildContext context) {
-//    final Completer<WeekModel> completer = Completer<WeekModel>();
-//
-//    api.week
-//        .update('123', mockWeek.weekYear, mockWeek.weekNumber, mockWeek)
-//        .listen(completer.complete);
-//
-//    return completer.future;
-//  }
-
   @override
   Observable<bool> get validTitleStream =>
       Observable<bool>.just(acceptAllInputs);

--- a/test/screens/new_weekplan_screen_test.dart
+++ b/test/screens/new_weekplan_screen_test.dart
@@ -13,6 +13,7 @@ import 'package:weekplanner/blocs/new_weekplan_bloc.dart';
 import 'package:weekplanner/blocs/pictogram_bloc.dart';
 import 'package:weekplanner/blocs/pictogram_image_bloc.dart';
 import 'package:weekplanner/blocs/toolbar_bloc.dart';
+import 'package:weekplanner/blocs/weekplan_selector_bloc.dart';
 import 'package:weekplanner/di.dart';
 import 'package:weekplanner/screens/new_weekplan_screen.dart';
 import 'package:weekplanner/screens/pictogram_search_screen.dart';
@@ -30,12 +31,8 @@ class MockNewWeekplanBloc extends NewWeekplanBloc {
 
   @override
   Observable<WeekModel> saveWeekplan() {
-    return api.week.update(
-        '123',
-        mockWeek.weekYear ,
-        mockWeek.weekNumber,
-        mockWeek
-    );
+    return api.week
+        .update('123', mockWeek.weekYear, mockWeek.weekNumber, mockWeek);
   }
 
   @override
@@ -82,6 +79,7 @@ final UsernameModel mockUser =
 
 void main() {
   MockNewWeekplanBloc mockBloc;
+  WeekplansBloc selectorBloc;
   Api api;
 
   setUp(() {
@@ -89,6 +87,7 @@ void main() {
     api.week = MockWeekApi();
     api.pictogram = MockPictogramApi();
     mockBloc = MockNewWeekplanBloc(api);
+    selectorBloc = WeekplansBloc(api);
 
     when(api.pictogram.getImage(mockPictogram.id))
         .thenAnswer((_) => BehaviorSubject<Image>.seeded(sampleImage));
@@ -106,31 +105,66 @@ void main() {
   });
 
   testWidgets('Screen renders', (WidgetTester tester) async {
-    await tester.pumpWidget(MaterialApp(home: NewWeekplanScreen(mockUser)));
+    await tester.pumpWidget(
+      MaterialApp(
+        home: NewWeekplanScreen(
+          mockUser,
+          selectorBloc: selectorBloc,
+        ),
+      ),
+    );
   });
 
   testWidgets('The screen has a Giraf App Bar', (WidgetTester tester) async {
-    await tester.pumpWidget(MaterialApp(home: NewWeekplanScreen(mockUser)));
+    await tester.pumpWidget(
+      MaterialApp(
+        home: NewWeekplanScreen(
+          mockUser,
+          selectorBloc: selectorBloc,
+        ),
+      ),
+    );
 
     expect(find.byWidgetPredicate((Widget widget) => widget is GirafAppBar),
         findsOneWidget);
   });
 
   testWidgets('Input fields are rendered', (WidgetTester tester) async {
-    await tester.pumpWidget(MaterialApp(home: NewWeekplanScreen(mockUser)));
+    await tester.pumpWidget(
+      MaterialApp(
+        home: NewWeekplanScreen(
+          mockUser,
+          selectorBloc: selectorBloc,
+        ),
+      ),
+    );
 
     expect(find.byType(TextField), findsNWidgets(3));
   });
 
   testWidgets('Pictograms are rendered', (WidgetTester tester) async {
-    await tester.pumpWidget(MaterialApp(home: NewWeekplanScreen(mockUser)));
+    await tester.pumpWidget(
+      MaterialApp(
+        home: NewWeekplanScreen(
+          mockUser,
+          selectorBloc: selectorBloc,
+        ),
+      ),
+    );
     await tester.pump();
 
     expect(find.byType(PictogramImage), findsOneWidget);
   });
 
   testWidgets('Buttons are rendered', (WidgetTester tester) async {
-    await tester.pumpWidget(MaterialApp(home: NewWeekplanScreen(mockUser)));
+    await tester.pumpWidget(
+      MaterialApp(
+        home: NewWeekplanScreen(
+          mockUser,
+          selectorBloc: selectorBloc,
+        ),
+      ),
+    );
 
     expect(find.byType(GirafButton), findsNWidgets(1));
   });
@@ -138,7 +172,14 @@ void main() {
   testWidgets('Error text is shown on invalid title input',
       (WidgetTester tester) async {
     mockBloc.acceptAllInputs = false;
-    await tester.pumpWidget(MaterialApp(home: NewWeekplanScreen(mockUser)));
+    await tester.pumpWidget(
+      MaterialApp(
+        home: NewWeekplanScreen(
+          mockUser,
+          selectorBloc: selectorBloc,
+        ),
+      ),
+    );
     await tester.pump();
 
     expect(find.text('Titel skal angives'), findsOneWidget);
@@ -147,7 +188,14 @@ void main() {
   testWidgets('No error text is shown on valid title input',
       (WidgetTester tester) async {
     mockBloc.acceptAllInputs = true;
-    await tester.pumpWidget(MaterialApp(home: NewWeekplanScreen(mockUser)));
+    await tester.pumpWidget(
+      MaterialApp(
+        home: NewWeekplanScreen(
+          mockUser,
+          selectorBloc: selectorBloc,
+        ),
+      ),
+    );
     await tester.pump();
 
     expect(find.text('Titel skal angives'), findsNothing);
@@ -156,7 +204,14 @@ void main() {
   testWidgets('Error text is shown on invalid year input',
       (WidgetTester tester) async {
     mockBloc.acceptAllInputs = false;
-    await tester.pumpWidget(MaterialApp(home: NewWeekplanScreen(mockUser)));
+    await tester.pumpWidget(
+      MaterialApp(
+        home: NewWeekplanScreen(
+          mockUser,
+          selectorBloc: selectorBloc,
+        ),
+      ),
+    );
     await tester.pump();
 
     expect(find.text('År skal angives som fire cifre'), findsOneWidget);
@@ -165,7 +220,14 @@ void main() {
   testWidgets('No error text is shown on valid year input',
       (WidgetTester tester) async {
     mockBloc.acceptAllInputs = true;
-    await tester.pumpWidget(MaterialApp(home: NewWeekplanScreen(mockUser)));
+    await tester.pumpWidget(
+      MaterialApp(
+        home: NewWeekplanScreen(
+          mockUser,
+          selectorBloc: selectorBloc,
+        ),
+      ),
+    );
     await tester.pump();
 
     expect(find.text('År skal angives som fire cifre'), findsNothing);
@@ -174,7 +236,14 @@ void main() {
   testWidgets('Error text is shown on invalid week number input',
       (WidgetTester tester) async {
     mockBloc.acceptAllInputs = false;
-    await tester.pumpWidget(MaterialApp(home: NewWeekplanScreen(mockUser)));
+    await tester.pumpWidget(
+      MaterialApp(
+        home: NewWeekplanScreen(
+          mockUser,
+          selectorBloc: selectorBloc,
+        ),
+      ),
+    );
     await tester.pump();
 
     expect(find.text('Ugenummer skal være mellem 1 og 53'), findsOneWidget);
@@ -183,7 +252,14 @@ void main() {
   testWidgets('No error text is shown on valid week number input',
       (WidgetTester tester) async {
     mockBloc.acceptAllInputs = true;
-    await tester.pumpWidget(MaterialApp(home: NewWeekplanScreen(mockUser)));
+    await tester.pumpWidget(
+      MaterialApp(
+        home: NewWeekplanScreen(
+          mockUser,
+          selectorBloc: selectorBloc,
+        ),
+      ),
+    );
     await tester.pump();
 
     expect(find.text('Ugenummer skal være mellem 1 og 53'), findsNothing);
@@ -191,7 +267,14 @@ void main() {
 
   testWidgets('Emojis are blacklisted from title field',
       (WidgetTester tester) async {
-    await tester.pumpWidget(MaterialApp(home: NewWeekplanScreen(mockUser)));
+    await tester.pumpWidget(
+      MaterialApp(
+        home: NewWeekplanScreen(
+          mockUser,
+          selectorBloc: selectorBloc,
+        ),
+      ),
+    );
     await tester.enterText(
         find.byKey(const Key('NewWeekplanTitleField')), '☺♥');
     await tester.pump();
@@ -202,7 +285,14 @@ void main() {
   testWidgets('Click on thumbnail redirects to pictogram search screen',
       (WidgetTester tester) async {
     mockBloc.acceptAllInputs = true;
-    await tester.pumpWidget(MaterialApp(home: NewWeekplanScreen(mockUser)));
+    await tester.pumpWidget(
+      MaterialApp(
+        home: NewWeekplanScreen(
+          mockUser,
+          selectorBloc: selectorBloc,
+        ),
+      ),
+    );
     await tester.tap(find.byKey(const Key('NewWeekplanThumbnailKey')));
     await tester.pumpAndSettle();
 
@@ -213,7 +303,14 @@ void main() {
       'Click on save weekplan button saves weekplan and return saved weekplan',
       (WidgetTester tester) async {
     mockBloc.acceptAllInputs = true;
-    await tester.pumpWidget(MaterialApp(home: NewWeekplanScreen(mockUser)));
+    await tester.pumpWidget(
+      MaterialApp(
+        home: NewWeekplanScreen(
+          mockUser,
+          selectorBloc: selectorBloc,
+        ),
+      ),
+    );
     await tester.pump();
     await tester.tap(find.byKey(const Key('NewWeekplanSaveBtnKey')));
 

--- a/test/screens/new_weekplan_screen_test.dart
+++ b/test/screens/new_weekplan_screen_test.dart
@@ -20,6 +20,7 @@ import 'package:weekplanner/blocs/weekplan_selector_bloc.dart';
 import 'package:weekplanner/di.dart';
 import 'package:weekplanner/screens/new_weekplan_screen.dart';
 import 'package:weekplanner/screens/pictogram_search_screen.dart';
+import 'package:weekplanner/screens/weekplan_selector_screen.dart';
 import 'package:weekplanner/widgets/giraf_app_bar_widget.dart';
 import 'package:weekplanner/widgets/giraf_button_widget.dart';
 import 'package:weekplanner/widgets/giraf_confirm_dialog.dart';
@@ -33,16 +34,17 @@ class MockNewWeekplanBloc extends NewWeekplanBloc {
   bool acceptAllInputs = true;
   Api api;
 
-  @override
-  Future<WeekModel> saveWeekplan(BuildContext context) {
-    final Completer<WeekModel> completer = Completer<WeekModel>();
+//  @override
+//  Future<WeekModel> saveWeekplan(BuildContext context) {
+//    final Completer<WeekModel> completer = Completer<WeekModel>();
+//
+//    api.week
+//        .update('123', mockWeek.weekYear, mockWeek.weekNumber, mockWeek)
+//        .listen(completer.complete);
+//
+//    return completer.future;
+//  }
 
-    api.week
-        .update('123', mockWeek.weekYear, mockWeek.weekNumber, mockWeek)
-        .listen(completer.complete);
-
-    return completer.future;
-  }
 
   @override
   Observable<bool> get validTitleStream =>
@@ -299,47 +301,38 @@ void main() {
       ),
     );
     await tester.pump();
-    await tester.tap(find.byKey(const Key('NewWeekplanSaveBtnKey')));
+    //await tester.tap(find.byKey(const Key('NewWeekplanSaveBtnKey')));
 
 // TODO: Fix this test.
     mockBloc.saveWeekplan(null).then((WeekModel response) async {
       expect(response, mockWeek);
+      await tester.pump();
     });
+
+    expect(
+        tester.widget<GirafButton>(find.byType(GirafButton)).isEnabled, isTrue);
   });
 
   testWidgets('Should show dialog if trying to overwrite',
       (WidgetTester tester) async {
+    mockBloc.acceptAllInputs = true;
     await tester.pumpWidget(
       MaterialApp(
         home: NewWeekplanScreen(mockUser),
       ),
     );
+
     await tester.pump();
-
-    await tester.enterText(
-        find.byKey(const Key('NewWeekplanTitleField')), mockWeek.name);
-    await tester.enterText(find.byKey(const Key('NewWeekplanYearField')),
-        mockWeek.weekYear.toString());
-    await tester.enterText(find.byKey(const Key('NewWeekplanWeekField')),
-        mockWeek.weekNumber.toString());
+    mockBloc.onTitleChanged.add(mockWeek.name);
+    mockBloc.onWeekNumberChanged.add(mockWeek.weekNumber.toString());
+    mockBloc.onYearChanged.add(mockWeek.weekYear.toString());
     mockBloc.onThumbnailChanged.add(mockWeek.thumbnail);
-
-    // expect(find.byType(PictogramImage), findsOneWidget);
-    // final Completer<bool> enabledCompleter = Completer<bool>();
-
-    // // tester
-    // //     .widget<GirafButton>(find.byType(GirafButton))
-    // //     .isEnabledStream
-    // //     .listen(enabledCompleter.complete);
-
-    // // final bool isEnabled = await enabledCompleter.future;
-
-    // // bool x = true;
-
-    // // expect(isEnabled, true);
 
     await tester.tap(find.byKey(const Key('NewWeekplanSaveBtnKey')));
     await tester.pumpAndSettle();
     expect(find.byType(GirafConfirmDialog), findsOneWidget);
+
   });
+
+
 }

--- a/test/screens/new_weekplan_screen_test.dart
+++ b/test/screens/new_weekplan_screen_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:api_client/api/api.dart';
 import 'package:api_client/api/pictogram_api.dart';
 import 'package:api_client/api/week_api.dart';
@@ -30,9 +32,14 @@ class MockNewWeekplanBloc extends NewWeekplanBloc {
   Api api;
 
   @override
-  Observable<WeekModel> saveWeekplan() {
-    return api.week
-        .update('123', mockWeek.weekYear, mockWeek.weekNumber, mockWeek);
+  Future<WeekModel> saveWeekplan(BuildContext context) {
+    final Completer<WeekModel> completer = Completer<WeekModel>();
+
+    api.week
+        .update('123', mockWeek.weekYear, mockWeek.weekNumber, mockWeek)
+        .listen(completer.complete);
+
+    return completer.future;
   }
 
   @override
@@ -86,7 +93,6 @@ void main() {
     api = Api('any');
     api.week = MockWeekApi();
     api.pictogram = MockPictogramApi();
-    mockBloc = MockNewWeekplanBloc(api);
     selectorBloc = WeekplansBloc(api);
 
     when(api.pictogram.getImage(mockPictogram.id))
@@ -97,20 +103,20 @@ void main() {
     });
 
     di.clearAll();
+    di.registerDependency<WeekplansBloc>((_) => WeekplansBloc(api));
     di.registerDependency<AuthBloc>((_) => AuthBloc(api));
     di.registerDependency<PictogramBloc>((_) => PictogramBloc(api));
     di.registerDependency<PictogramImageBloc>((_) => PictogramImageBloc(api));
     di.registerDependency<ToolbarBloc>((_) => ToolbarBloc());
     di.registerDependency<NewWeekplanBloc>((_) => mockBloc);
+
+    mockBloc = MockNewWeekplanBloc(api);
   });
 
   testWidgets('Screen renders', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
-        home: NewWeekplanScreen(
-          mockUser,
-          selectorBloc: selectorBloc,
-        ),
+        home: NewWeekplanScreen(mockUser),
       ),
     );
   });
@@ -118,10 +124,7 @@ void main() {
   testWidgets('The screen has a Giraf App Bar', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
-        home: NewWeekplanScreen(
-          mockUser,
-          selectorBloc: selectorBloc,
-        ),
+        home: NewWeekplanScreen(mockUser),
       ),
     );
 
@@ -132,10 +135,7 @@ void main() {
   testWidgets('Input fields are rendered', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
-        home: NewWeekplanScreen(
-          mockUser,
-          selectorBloc: selectorBloc,
-        ),
+        home: NewWeekplanScreen(mockUser),
       ),
     );
 
@@ -145,10 +145,7 @@ void main() {
   testWidgets('Pictograms are rendered', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
-        home: NewWeekplanScreen(
-          mockUser,
-          selectorBloc: selectorBloc,
-        ),
+        home: NewWeekplanScreen(mockUser),
       ),
     );
     await tester.pump();
@@ -159,10 +156,7 @@ void main() {
   testWidgets('Buttons are rendered', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
-        home: NewWeekplanScreen(
-          mockUser,
-          selectorBloc: selectorBloc,
-        ),
+        home: NewWeekplanScreen(mockUser),
       ),
     );
 
@@ -174,10 +168,7 @@ void main() {
     mockBloc.acceptAllInputs = false;
     await tester.pumpWidget(
       MaterialApp(
-        home: NewWeekplanScreen(
-          mockUser,
-          selectorBloc: selectorBloc,
-        ),
+        home: NewWeekplanScreen(mockUser),
       ),
     );
     await tester.pump();
@@ -190,10 +181,7 @@ void main() {
     mockBloc.acceptAllInputs = true;
     await tester.pumpWidget(
       MaterialApp(
-        home: NewWeekplanScreen(
-          mockUser,
-          selectorBloc: selectorBloc,
-        ),
+        home: NewWeekplanScreen(mockUser),
       ),
     );
     await tester.pump();
@@ -206,10 +194,7 @@ void main() {
     mockBloc.acceptAllInputs = false;
     await tester.pumpWidget(
       MaterialApp(
-        home: NewWeekplanScreen(
-          mockUser,
-          selectorBloc: selectorBloc,
-        ),
+        home: NewWeekplanScreen(mockUser),
       ),
     );
     await tester.pump();
@@ -222,10 +207,7 @@ void main() {
     mockBloc.acceptAllInputs = true;
     await tester.pumpWidget(
       MaterialApp(
-        home: NewWeekplanScreen(
-          mockUser,
-          selectorBloc: selectorBloc,
-        ),
+        home: NewWeekplanScreen(mockUser),
       ),
     );
     await tester.pump();
@@ -238,10 +220,7 @@ void main() {
     mockBloc.acceptAllInputs = false;
     await tester.pumpWidget(
       MaterialApp(
-        home: NewWeekplanScreen(
-          mockUser,
-          selectorBloc: selectorBloc,
-        ),
+        home: NewWeekplanScreen(mockUser),
       ),
     );
     await tester.pump();
@@ -254,10 +233,7 @@ void main() {
     mockBloc.acceptAllInputs = true;
     await tester.pumpWidget(
       MaterialApp(
-        home: NewWeekplanScreen(
-          mockUser,
-          selectorBloc: selectorBloc,
-        ),
+        home: NewWeekplanScreen(mockUser),
       ),
     );
     await tester.pump();
@@ -269,10 +245,7 @@ void main() {
       (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
-        home: NewWeekplanScreen(
-          mockUser,
-          selectorBloc: selectorBloc,
-        ),
+        home: NewWeekplanScreen(mockUser),
       ),
     );
     await tester.enterText(
@@ -287,10 +260,7 @@ void main() {
     mockBloc.acceptAllInputs = true;
     await tester.pumpWidget(
       MaterialApp(
-        home: NewWeekplanScreen(
-          mockUser,
-          selectorBloc: selectorBloc,
-        ),
+        home: NewWeekplanScreen(mockUser),
       ),
     );
     await tester.tap(find.byKey(const Key('NewWeekplanThumbnailKey')));
@@ -305,16 +275,14 @@ void main() {
     mockBloc.acceptAllInputs = true;
     await tester.pumpWidget(
       MaterialApp(
-        home: NewWeekplanScreen(
-          mockUser,
-          selectorBloc: selectorBloc,
-        ),
+        home: NewWeekplanScreen(mockUser),
       ),
     );
     await tester.pump();
     await tester.tap(find.byKey(const Key('NewWeekplanSaveBtnKey')));
 
-    mockBloc.saveWeekplan().listen((WeekModel response) async {
+// TODO: Fix this test.
+    mockBloc.saveWeekplan(null).then((WeekModel response) async {
       expect(response, mockWeek);
     });
   });

--- a/test/screens/new_weekplan_screen_test.dart
+++ b/test/screens/new_weekplan_screen_test.dart
@@ -45,7 +45,6 @@ class MockNewWeekplanBloc extends NewWeekplanBloc {
 //    return completer.future;
 //  }
 
-
   @override
   Observable<bool> get validTitleStream =>
       Observable<bool>.just(acceptAllInputs);
@@ -331,8 +330,27 @@ void main() {
     await tester.tap(find.byKey(const Key('NewWeekplanSaveBtnKey')));
     await tester.pumpAndSettle();
     expect(find.byType(GirafConfirmDialog), findsOneWidget);
-
   });
 
+  testWidgets('Should show expected message when trying to overwrite',
+      (WidgetTester tester) async {
+    mockBloc.acceptAllInputs = true;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: NewWeekplanScreen(mockUser),
+      ),
+    );
 
+    await tester.pump();
+    mockBloc.onTitleChanged.add(mockWeek.name);
+    mockBloc.onWeekNumberChanged.add(mockWeek.weekNumber.toString());
+    mockBloc.onYearChanged.add(mockWeek.weekYear.toString());
+    mockBloc.onThumbnailChanged.add(mockWeek.thumbnail);
+
+    await tester.tap(find.byKey(const Key('NewWeekplanSaveBtnKey')));
+    await tester.pumpAndSettle();
+    expect(find.text('Ugeplanen (uge: '+mockWeek.weekNumber.toString()+
+        ', år: '+mockWeek.weekYear.toString()+') eksisterer '
+        'allerede. Vil du overskrive denne ugeplan?'), findsOneWidget);
+  });
 }

--- a/test/screens/new_weekplan_screen_test.dart
+++ b/test/screens/new_weekplan_screen_test.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:api_client/api/api.dart';
 import 'package:api_client/api/pictogram_api.dart';
 import 'package:api_client/api/week_api.dart';
@@ -20,7 +18,6 @@ import 'package:weekplanner/blocs/weekplan_selector_bloc.dart';
 import 'package:weekplanner/di.dart';
 import 'package:weekplanner/screens/new_weekplan_screen.dart';
 import 'package:weekplanner/screens/pictogram_search_screen.dart';
-import 'package:weekplanner/screens/weekplan_selector_screen.dart';
 import 'package:weekplanner/widgets/giraf_app_bar_widget.dart';
 import 'package:weekplanner/widgets/giraf_button_widget.dart';
 import 'package:weekplanner/widgets/giraf_confirm_dialog.dart';
@@ -105,7 +102,7 @@ void main() {
 
     when(api.week.getNames(any)).thenAnswer(
       (_) {
-        return Observable<List<WeekNameModel>>.just([
+        return Observable<List<WeekNameModel>>.just(<WeekNameModel>[
           WeekNameModel(
               name: mockWeek.name,
               weekNumber: mockWeek.weekNumber,
@@ -149,7 +146,9 @@ void main() {
       ),
     );
 
-    expect(find.byWidgetPredicate((Widget widget) => widget is GirafAppBar),
+    expect(
+        find.byWidgetPredicate((Widget widget) =>
+        widget is GirafAppBar && widget.title == 'Ny ugeplan'),
         findsOneWidget);
   });
 
@@ -311,7 +310,6 @@ void main() {
 
   testWidgets('Should show overwrite dialog if trying to overwrite',
       (WidgetTester tester) async {
-    mockBloc.acceptAllInputs = true;
     await tester.pumpWidget(
       MaterialApp(
         home: NewWeekplanScreen(mockUser),

--- a/test/screens/new_weekplan_screen_test.dart
+++ b/test/screens/new_weekplan_screen_test.dart
@@ -31,17 +31,6 @@ class MockNewWeekplanBloc extends NewWeekplanBloc {
   bool acceptAllInputs = true;
   Api api;
 
-//  @override
-//  Future<WeekModel> saveWeekplan(BuildContext context) {
-//    final Completer<WeekModel> completer = Completer<WeekModel>();
-//
-//    api.week
-//        .update('123', mockWeek.weekYear, mockWeek.weekNumber, mockWeek)
-//        .listen(completer.complete);
-//
-//    return completer.future;
-//  }
-
   @override
   Observable<bool> get validTitleStream =>
       Observable<bool>.just(acceptAllInputs);
@@ -311,12 +300,6 @@ void main() {
     await tester.tap(find.byKey(const Key('NewWeekplanSaveBtnKey')));
 
     expect(savedWeekplan, true);
-
-// TODO: Fix this test.
-//    mockBloc.saveWeekplan(null).then((WeekModel response) async {
-//      expect(response, mockWeek);
-//      await tester.pump();
-//    });
   });
 
   testWidgets('Should show overwrite dialog if trying to overwrite',

--- a/test/screens/new_weekplan_screen_test.dart
+++ b/test/screens/new_weekplan_screen_test.dart
@@ -86,14 +86,12 @@ final UsernameModel mockUser =
 
 void main() {
   MockNewWeekplanBloc mockBloc;
-  WeekplansBloc selectorBloc;
   Api api;
 
   setUp(() {
     api = Api('any');
     api.week = MockWeekApi();
     api.pictogram = MockPictogramApi();
-    selectorBloc = WeekplansBloc(api);
 
     when(api.pictogram.getImage(mockPictogram.id))
         .thenAnswer((_) => BehaviorSubject<Image>.seeded(sampleImage));

--- a/test/screens/new_weekplan_screen_test.dart
+++ b/test/screens/new_weekplan_screen_test.dart
@@ -300,16 +300,13 @@ void main() {
       ),
     );
     await tester.pump();
-    //await tester.tap(find.byKey(const Key('NewWeekplanSaveBtnKey')));
+    await tester.tap(find.byKey(const Key('NewWeekplanSaveBtnKey')));
 
 // TODO: Fix this test.
     mockBloc.saveWeekplan(null).then((WeekModel response) async {
       expect(response, mockWeek);
       await tester.pump();
     });
-
-    expect(
-        tester.widget<GirafButton>(find.byType(GirafButton)).isEnabled, isTrue);
   });
 
   testWidgets('Should show overwrite dialog if trying to overwrite',

--- a/test/screens/new_weekplan_screen_test.dart
+++ b/test/screens/new_weekplan_screen_test.dart
@@ -312,7 +312,7 @@ void main() {
         tester.widget<GirafButton>(find.byType(GirafButton)).isEnabled, isTrue);
   });
 
-  testWidgets('Should show dialog if trying to overwrite',
+  testWidgets('Should show overwrite dialog if trying to overwrite',
       (WidgetTester tester) async {
     mockBloc.acceptAllInputs = true;
     await tester.pumpWidget(
@@ -322,35 +322,24 @@ void main() {
     );
 
     await tester.pump();
-    mockBloc.onTitleChanged.add(mockWeek.name);
-    mockBloc.onWeekNumberChanged.add(mockWeek.weekNumber.toString());
-    mockBloc.onYearChanged.add(mockWeek.weekYear.toString());
+    await tester.enterText(
+        find.byKey(const Key('NewWeekplanTitleField')), mockWeek.name);
+    await tester.enterText(find.byKey(const Key('NewWeekplanYearField')),
+        mockWeek.weekYear.toString());
+    await tester.enterText(find.byKey(const Key('NewWeekplanWeekField')),
+        mockWeek.weekNumber.toString());
     mockBloc.onThumbnailChanged.add(mockWeek.thumbnail);
 
     await tester.tap(find.byKey(const Key('NewWeekplanSaveBtnKey')));
     await tester.pumpAndSettle();
     expect(find.byType(GirafConfirmDialog), findsOneWidget);
-  });
-
-  testWidgets('Should show expected message when trying to overwrite',
-      (WidgetTester tester) async {
-    mockBloc.acceptAllInputs = true;
-    await tester.pumpWidget(
-      MaterialApp(
-        home: NewWeekplanScreen(mockUser),
-      ),
-    );
-
-    await tester.pump();
-    mockBloc.onTitleChanged.add(mockWeek.name);
-    mockBloc.onWeekNumberChanged.add(mockWeek.weekNumber.toString());
-    mockBloc.onYearChanged.add(mockWeek.weekYear.toString());
-    mockBloc.onThumbnailChanged.add(mockWeek.thumbnail);
-
-    await tester.tap(find.byKey(const Key('NewWeekplanSaveBtnKey')));
-    await tester.pumpAndSettle();
-    expect(find.text('Ugeplanen (uge: '+mockWeek.weekNumber.toString()+
-        ', år: '+mockWeek.weekYear.toString()+') eksisterer '
-        'allerede. Vil du overskrive denne ugeplan?'), findsOneWidget);
+    expect(
+        find.text('Ugeplanen (uge: ' +
+            mockWeek.weekNumber.toString() +
+            ', år: ' +
+            mockWeek.weekYear.toString() +
+            ') eksisterer '
+                'allerede. Vil du overskrive denne ugeplan?'),
+        findsOneWidget);
   });
 }


### PR DESCRIPTION
Closes #310

Added an overwrite dialog when overwriting an existing weekplan for both when creating a new weekplan and when editing an existing weekplan. 
Added new widget tests to new_weekplan_screen_test.dart and edit_weekplan_screen_test.dart.
Added new unit tests to new_weekplan_bloc_test.dart and  edit_weekplan_bloc_test.dart.
Tests were missing for edit_weekplan_screen_test.dart , so tests was copied and edited from new_weekplan_screen_test.dart, since both screens are almost identical. 