### PR TITLE
Fixes 413

### DIFF
--- a/lib/blocs/weekplan_bloc.dart
+++ b/lib/blocs/weekplan_bloc.dart
@@ -230,7 +230,7 @@ class WeekplanBloc extends BlocBase {
     _api.week
         .update(user.id, week.weekYear, week.weekNumber, week)
         .listen((WeekModel newWeek) {
-      _userWeek.add(UserWeekModel(week, user));
+      _userWeek.add(UserWeekModel(newWeek, user));
     });
   }
 


### PR DESCRIPTION
Fixes #413 
Only changes one variable, Which caused another bug, where the timer first disappeared after leaving the weekplan and reopening. Now the bug of the timer disappearing also happens immediately when reordering.
This issue's bug is in the web-api and not the weekplanner, so an issue will be made for the web-api instead. 
