### PR TITLE
Update environments.prod.json to use DEV server during pre-release

### DIFF
--- a/assets/environments.prod.json
+++ b/assets/environments.prod.json
@@ -1,4 +1,4 @@
 {
-  "SERVER_HOST": "https://srv.giraf.cs.aau.dk/PROD/API",
+  "SERVER_HOST": "https://srv.giraf.cs.aau.dk/DEV/API",
   "DEBUG": false
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   api_client:
     git:
       url: https://github.com/aau-giraf/api_client.git
-      ref: master
+      ref: release/2020S3R1
   auto_size_text: ^1.1.1
   image_picker: ^0.6.0+2
   rflutter_alert: ^1.0.2


### PR DESCRIPTION
In order to make sure that we are using the release build on the web-api

This will be removed again when the release is merged into master