### PR TITLE
ReleaseFix to 541

### DIFF
--- a/lib/blocs/copy_weekplan_bloc.dart
+++ b/lib/blocs/copy_weekplan_bloc.dart
@@ -81,8 +81,17 @@ class CopyWeekplanBloc extends ChooseCitizenBloc {
     if(response.days == null){
       return false;
     }
+
     for (WeekdayModel weekDay in response.days) {
       daysAreEmpty = daysAreEmpty && weekDay.activities.isEmpty;
+    }
+
+    ///Checks whether the name of the week model is different from the default
+    /// created when no week exists
+    if(daysAreEmpty) {
+      int weekYear = weekModel.weekYear;
+      int weekNumber = weekModel.weekNumber;
+      daysAreEmpty = response.name.compareTo("$weekYear - $weekNumber") == 0;
     }
 
     return !daysAreEmpty;

--- a/lib/blocs/copy_weekplan_bloc.dart
+++ b/lib/blocs/copy_weekplan_bloc.dart
@@ -89,9 +89,9 @@ class CopyWeekplanBloc extends ChooseCitizenBloc {
     ///Checks whether the name of the week model is different from the default
     /// created when no week exists
     if(daysAreEmpty) {
-      int weekYear = weekModel.weekYear;
-      int weekNumber = weekModel.weekNumber;
-      daysAreEmpty = response.name.compareTo("$weekYear - $weekNumber") == 0;
+      final int weekYear = weekModel.weekYear;
+      final int weekNumber = weekModel.weekNumber;
+      daysAreEmpty = response.name.compareTo('$weekYear - $weekNumber') == 0;
     }
 
     return !daysAreEmpty;

--- a/test/screens/copy_resolve_screen_test.dart
+++ b/test/screens/copy_resolve_screen_test.dart
@@ -2,7 +2,6 @@ import 'package:api_client/api/week_api.dart';
 import 'package:api_client/models/displayname_model.dart';
 import 'package:api_client/models/week_model.dart';
 import 'package:api_client/models/week_name_model.dart';
-import 'package:api_client/models/weekday_model.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';

--- a/test/screens/copy_resolve_screen_test.dart
+++ b/test/screens/copy_resolve_screen_test.dart
@@ -32,8 +32,6 @@ class MockCopyResolveBloc extends CopyResolveBloc {
   Observable<bool> get allInputsAreValidStream => Observable<bool>.just(true);
 }
 
-final WeekModel emptyWeekmodel = WeekModel(days: <WeekdayModel>[]);
-
 final List<WeekNameModel> weekNameModelList = <WeekNameModel>[];
 final WeekNameModel weekNameModel =
 WeekNameModel(name: 'weekplan1', weekNumber: 2020, weekYear: 32);
@@ -88,7 +86,8 @@ void main() {
           return Observable<WeekModel>.just(weekplan1Copy);
         }
       }
-      return Observable<WeekModel>.just(emptyWeekmodel);
+      return Observable<WeekModel>.just(WeekModel(
+        thumbnail: null, name: '2020 - 3', weekYear: 2020, weekNumber: 3));
     });
 
     when(api.week

--- a/test/screens/copy_to_citizens_screen_test.dart
+++ b/test/screens/copy_to_citizens_screen_test.dart
@@ -66,7 +66,9 @@ class MockWeekApi extends Mock implements WeekApi {
     ]);
     return hasConflict
         ? Observable<WeekModel>.just(weekModel)
-        : Observable<WeekModel>.just(emptyWeekmodel);
+        : Observable<WeekModel>.just(WeekModel(
+        thumbnail: null, name: '$year - $weekNumber', weekYear: year,
+        weekNumber: weekNumber));
   }
 
   @override
@@ -82,8 +84,6 @@ final DisplayNameModel user1 =
 
 final DisplayNameModel user2 = DisplayNameModel(
     id: 'test2Id', displayName: 'test2Name', role: 'test2Role');
-
-final WeekModel emptyWeekmodel = WeekModel(days: <WeekdayModel>[]);
 
 void main() {
   CopyWeekplanBloc bloc;


### PR DESCRIPTION
Fixes #541 
There is one instance where naming the weekplan "`weekYear` - `weekNumber`" will still reproduce the bug. 
However, solving this would require bigger changes to the web-api and how it handles not finding a week plan for a user, and after a discussion with PO was moved to a new issue. 
New issue created for fixing this #547 
