### PR TITLE
Feature 527: Opacity changed to 40% on disabled buttons

### DIFF
--- a/lib/style/custom_color.dart
+++ b/lib/style/custom_color.dart
@@ -62,16 +62,16 @@ class GirafColors {
   static const Color gradientPressedOrange = Color(0xFFFF9D00);
 
   /// Border color for button pressed gradient
-  static const Color gradientPressedBorder = Color(0xFF493700);
+  static const Color gradientPressedBorder = Color(0x66493700);
 
   /// Yellow color for button disabled gradient
-  static const Color gradientDisabledYellow = Color(0x46FFCD59);
+  static const Color gradientDisabledYellow = Color(0x66FFCD59);
 
   /// Orange color for button disabled gradient
-  static const Color gradientDisabledOrange = Color(0xA6FF9D00);
+  static const Color gradientDisabledOrange = Color(0x66FF9D00);
 
   /// Border color for button disabled gradient
-  static const Color gradientDisabledBorder = Color(0xA68A6E00);
+  static const Color gradientDisabledBorder = Color(0x668A6E00);
 
   /// Color for the loading spinner
   static const Color loadingColor = Color.fromRGBO(255, 157, 0, 0.8);

--- a/lib/style/custom_color.dart
+++ b/lib/style/custom_color.dart
@@ -62,7 +62,7 @@ class GirafColors {
   static const Color gradientPressedOrange = Color(0xFFFF9D00);
 
   /// Border color for button pressed gradient
-  static const Color gradientPressedBorder = Color(0x66493700);
+  static const Color gradientPressedBorder = Color(0xFF493700);
 
   /// Yellow color for button disabled gradient
   static const Color gradientDisabledYellow = Color(0x66FFCD59);


### PR DESCRIPTION
In the file lib/style/custom_color.dart the opacity for the disabled button has been changed from 65%(A6) to 40%(66), and the border has been changed from 100% opacity (FF) to 40% (66). The gradient has also been changed from 27% (46) to 40% (66).