### PR TITLE
Feature 531: Pictogram title text no longer in all caps

### DIFF
--- a/lib/widgets/pictogram_text.dart
+++ b/lib/widgets/pictogram_text.dart
@@ -72,7 +72,7 @@ class PictogramText extends StatelessWidget {
           padding: EdgeInsets.symmetric(
               horizontal: MediaQuery.of(context).size.width * 0.05),
           child: AutoSizeText(
-            pictogramText,
+            pictogramText[0] + pictogramText.substring(1).toLowerCase(),
             minFontSize: minFontSize,
             maxLines: 2,
             textAlign: TextAlign.center,

--- a/test/screens/weekplan_screen_test.dart
+++ b/test/screens/weekplan_screen_test.dart
@@ -626,7 +626,7 @@ void main() {
     // Get the title of the activity
     final String title = mockActivities[0].pictograms.first.title;
 
-    expect(find.text(title.toUpperCase()), findsOneWidget);
+    expect(find.text(title[0].toUpperCase() + title.substring(1).toLowerCase()), findsOneWidget);
   });
 
   testWidgets('Changing to Citizen works', (WidgetTester tester) async {

--- a/test/screens/weekplan_screen_test.dart
+++ b/test/screens/weekplan_screen_test.dart
@@ -626,7 +626,8 @@ void main() {
     // Get the title of the activity
     final String title = mockActivities[0].pictograms.first.title;
 
-    expect(find.text(title[0].toUpperCase() + title.substring(1).toLowerCase()), findsOneWidget);
+    expect(find.text(title[0].toUpperCase() + title.substring(1).toLowerCase()),
+        findsOneWidget);
   });
 
   testWidgets('Changing to Citizen works', (WidgetTester tester) async {

--- a/test/widgets/pictogram_text_test.dart
+++ b/test/widgets/pictogram_text_test.dart
@@ -109,8 +109,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byType(AutoSizeText), findsOneWidget);
-    final String title = pictogramModel.title;
-    expect(find.text(title.toUpperCase()), findsOneWidget);
+    expect(find.text('Sometitle'), findsOneWidget);
   });
 
   testWidgets('Pictogram text is displayed when true and in guardian mode',
@@ -123,8 +122,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byType(AutoSizeText), findsOneWidget);
-    final String title = pictogramModel.title;
-    expect(find.text(title.toUpperCase()), findsOneWidget);
+    expect(find.text('Sometitle'), findsOneWidget);
   });
 
   testWidgets('Pictogram text is displayed when false and in guardian mode',
@@ -137,7 +135,6 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byType(AutoSizeText), findsOneWidget);
-    final String title = pictogramModel.title;
-    expect(find.text(title.toUpperCase()), findsOneWidget);
+    expect(find.text('Sometitle'), findsOneWidget);
   });
 }


### PR DESCRIPTION
Pictogram title texts are no longer in all caps, but the first letter is capitalized and the remaining are lower case.
Tests have been performed with expected results.
No additional tests failed.