### PR TITLE
Feature 495: Changed pictogram box changes

### DIFF
--- a/lib/widgets/pictogram_text.dart
+++ b/lib/widgets/pictogram_text.dart
@@ -65,16 +65,20 @@ class PictogramText extends StatelessWidget {
   }
 
   SizedBox _buildPictogramText(BuildContext context, String pictogramText) {
+    // count the amount of words by splitting by the spaces and count the result
+    // if theres only 1 word then max lines is 1 else the max lines is 2
+    final int textLines =
+        pictogramText.split(RegExp('\\s+')).length > 1 ? 2 : 1;
     return SizedBox(
         width: MediaQuery.of(context).size.width,
-        height: MediaQuery.of(context).size.width / 4,
+        height: null,
         child: Padding(
           padding: EdgeInsets.symmetric(
               horizontal: MediaQuery.of(context).size.width * 0.05),
           child: AutoSizeText(
             pictogramText,
             minFontSize: minFontSize,
-            maxLines: 2,
+            maxLines: textLines,
             textAlign: TextAlign.center,
             // creates a ... postfix if text overflows
             overflow: TextOverflow.ellipsis,

--- a/lib/widgets/pictogram_text.dart
+++ b/lib/widgets/pictogram_text.dart
@@ -65,10 +65,6 @@ class PictogramText extends StatelessWidget {
   }
 
   SizedBox _buildPictogramText(BuildContext context, String pictogramText) {
-    // count the amount of words by splitting by the spaces and count the result
-    // if theres only 1 word then max lines is 1 else the max lines is 2
-    final int textLines =
-        pictogramText.split(RegExp('\\s+')).length > 1 ? 2 : 1;
     return SizedBox(
         width: MediaQuery.of(context).size.width,
         height: null,
@@ -78,12 +74,43 @@ class PictogramText extends StatelessWidget {
           child: AutoSizeText(
             pictogramText,
             minFontSize: minFontSize,
-            maxLines: textLines,
+            maxLines: textLines(pictogramText, context),
             textAlign: TextAlign.center,
             // creates a ... postfix if text overflows
             overflow: TextOverflow.ellipsis,
             style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 150),
           ),
         ));
+  }
+}
+
+/// Try to calculate the actual size of the text, with the size of the screen
+/// accounted for
+double textWidth(String text, BuildContext context) {
+  return (TextPainter(
+          text: TextSpan(
+              text: text,
+              style:
+                  const TextStyle(fontWeight: FontWeight.bold, fontSize: 120)),
+          maxLines: 1,
+          textScaleFactor: MediaQuery.of(context).textScaleFactor,
+          textDirection: TextDirection.ltr)
+        ..layout())
+      .size
+      .width;
+}
+
+/// Counts the amount of words by splitting by the spaces and count the result
+/// if theres only 1 word then max lines is 1 else the max lines is 2
+int textLines(String pictogramText, BuildContext context) {
+  if (pictogramText.split(RegExp('\\s+')).length > 1) {
+    return 2;
+  } else {
+    if (textWidth(pictogramText, context) >=
+        MediaQuery.of(context).size.width) {
+      return 2;
+    } else {
+      return 1;
+    }
   }
 }


### PR DESCRIPTION
fixes #495 
The Issue was that some text was cut off when it spanned multiple lines, as the box size was static. this has been solved by allowing the pictogram box to be as high as the elements within and set the max amount of lines for the text to 2.

this made smaller words split into 2 lines, which was further solved by only allowing the text to be 1 line of only 1 word was present in the string.