### PR TITLE
Releasefix 570: Created class for converting Error codes to Danish messages

### DIFF
--- a/lib/api/errorcode_translater.dart
+++ b/lib/api/errorcode_translater.dart
@@ -1,8 +1,27 @@
 import 'package:api_client/models/enums/error_key.dart';
 import 'package:api_client/api/api_exception.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:weekplanner/widgets/giraf_notify_dialog.dart';
 
 /// Class for translating error codes to readable messages for the users
 class ApiErrorTranslater {
+  /// Catch errors thrown by the api_clien
+  /// (Can only handle ApiExceptions for now)
+  void catchApiError(Object error, BuildContext context) {
+    showDialog<Center>(
+
+        /// exception handler to handle web_api exceptions
+        barrierDismissible: false,
+        context: context,
+        builder: (BuildContext context) {
+          return GirafNotifyDialog(
+              title: 'Fejl',
+              description: getErrorMessage(error),
+              key: const Key('ErrorMessageDialog'));
+        });
+  }
+
   ///Get apropriate error message based on error code
   String getErrorMessage(ApiException error) {
     switch (error.errorKey) {

--- a/lib/api/errorcode_translater.dart
+++ b/lib/api/errorcode_translater.dart
@@ -1,0 +1,22 @@
+import 'package:api_client/models/enums/error_key.dart';
+import 'package:api_client/api/api_exception.dart';
+
+/// Class for translating error codes to readable messages for the users
+class ApiErrorTranslater {
+  ///Get apropriate error message based on error code
+  String getErrorMessage(ApiException error) {
+    switch (error.errorKey) {
+      case ErrorKey.UserAlreadyExists:
+        return 'Brugernavnet eksisterer allerede';
+      case ErrorKey.Error:
+        // Undefined errors, the message is in english
+        // as we cant predict why it was cast
+        return 'message: ' +
+            error.errorMessage +
+            '\nDetails: ' +
+            error.errorDetails;
+      default:
+        return 'Ukendt fejl';
+    }
+  }
+}

--- a/lib/api/errorcode_translater.dart
+++ b/lib/api/errorcode_translater.dart
@@ -1,6 +1,5 @@
 import 'package:api_client/models/enums/error_key.dart';
 import 'package:api_client/api/api_exception.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:weekplanner/widgets/giraf_notify_dialog.dart';
 

--- a/lib/screens/new_citizen_screen.dart
+++ b/lib/screens/new_citizen_screen.dart
@@ -1,10 +1,8 @@
-import 'package:api_client/api/api_exception.dart';
 import 'package:api_client/models/giraf_user_model.dart';
 import 'package:flutter/material.dart';
 import 'package:weekplanner/blocs/new_citizen_bloc.dart';
 import 'package:weekplanner/api/errorcode_translater.dart';
 import 'package:weekplanner/di.dart';
-import 'package:weekplanner/widgets/giraf_notify_dialog.dart';
 import 'package:weekplanner/routes.dart';
 import 'package:weekplanner/widgets/giraf_app_bar_widget.dart';
 import 'package:weekplanner/widgets/giraf_button_widget.dart';

--- a/lib/screens/new_citizen_screen.dart
+++ b/lib/screens/new_citizen_screen.dart
@@ -1,7 +1,9 @@
 import 'package:api_client/api/api_exception.dart';
+
 import 'package:api_client/models/giraf_user_model.dart';
 import 'package:flutter/material.dart';
 import 'package:weekplanner/blocs/new_citizen_bloc.dart';
+import 'package:weekplanner/api/errorcode_translater.dart';
 import 'package:weekplanner/di.dart';
 import 'package:weekplanner/widgets/giraf_notify_dialog.dart';
 import 'package:weekplanner/routes.dart';
@@ -14,6 +16,8 @@ class NewCitizenScreen extends StatelessWidget {
   NewCitizenScreen() : _bloc = di.getDependency<NewCitizenBloc>() {
     _bloc.initialize();
   }
+
+  final ApiErrorTranslater _translator = ApiErrorTranslater();
 
   final NewCitizenBloc _bloc;
   @override
@@ -136,7 +140,7 @@ class NewCitizenScreen extends StatelessWidget {
                           final ApiException apiError = error;
                           return GirafNotifyDialog(
                               title: 'Fejl',
-                              description: apiError.errorMessage,
+                              description: _translator.getErrorMessage(error),
                               key: Key(apiError.errorKey.toString()));
                         }));
                   },

--- a/lib/screens/new_citizen_screen.dart
+++ b/lib/screens/new_citizen_screen.dart
@@ -1,5 +1,4 @@
 import 'package:api_client/api/api_exception.dart';
-
 import 'package:api_client/models/giraf_user_model.dart';
 import 'package:flutter/material.dart';
 import 'package:weekplanner/blocs/new_citizen_bloc.dart';
@@ -131,18 +130,8 @@ class NewCitizenScreen extends StatelessWidget {
                         Routes.pop<GirafUserModel>(context, response);
                         _bloc.resetBloc();
                       }
-                    }).onError((Object error) => showDialog<Center>(
-
-                        /// exception handler to handle web_api exceptions
-                        barrierDismissible: false,
-                        context: context,
-                        builder: (BuildContext context) {
-                          final ApiException apiError = error;
-                          return GirafNotifyDialog(
-                              title: 'Fejl',
-                              description: _translator.getErrorMessage(error),
-                              key: Key(apiError.errorKey.toString()));
-                        }));
+                    }).onError((Object error) =>
+                        _translator.catchApiError(error, context));
                   },
                 ),
               ),

--- a/test/screens/new_citizen_screen_test.dart
+++ b/test/screens/new_citizen_screen_test.dart
@@ -20,10 +20,14 @@ import 'package:weekplanner/screens/new_citizen_screen.dart';
 import 'package:weekplanner/widgets/giraf_app_bar_widget.dart';
 import 'package:weekplanner/widgets/giraf_button_widget.dart';
 
+/// Mock Account Api needed to insert errors int othe datastream from a place
+/// where listen().onError could catch it
 class MockAccountApi extends AccountApi {
   MockAccountApi(PersistenceClient persist)
       : super(HttpClient(baseUrl: null, persist: persist), persist);
 
+  /// override of the register function, which returns an error
+  /// if 'username' == alreadyExists. Returns a normal GirafUserModel otherwise
   @override
   Observable<GirafUserModel> register(
       String username, String password, String displayName,
@@ -50,6 +54,7 @@ class MockAccountApi extends AccountApi {
     return Observable<GirafUserModel>.fromFuture(createMockUserModel(body));
   }
 
+  /// Creates the Error for the stream
   Future<Response> futureMockResponse(http.Response response) async {
     return Response(response, <String, dynamic>{
       'message': 'User already exists',
@@ -58,12 +63,13 @@ class MockAccountApi extends AccountApi {
     });
   }
 
-  // ignore: missing_return
+  /// Creates the model for the stream
   Future<GirafUserModel> createMockUserModel(Map<String, dynamic> body) async {
     return GirafUserModel.fromJson(body);
   }
 }
 
+/// Mock api needed to chance the UserApi to MockUserApi
 class MockApi extends Api {
   MockApi(String baseUrl) : super(baseUrl) {
     account = MockAccountApi(PersistenceClient());

--- a/test/screens/new_citizen_screen_test.dart
+++ b/test/screens/new_citizen_screen_test.dart
@@ -1,5 +1,11 @@
+import 'package:api_client/api/account_api.dart';
+import 'package:api_client/api_client.dart';
+import 'package:api_client/persistence/persistence_client.dart';
+import 'package:http/http.dart' as http;
 import 'package:api_client/api/api.dart';
+import 'package:api_client/api/api_exception.dart';
 import 'package:api_client/api/user_api.dart';
+import 'package:api_client/http/http.dart';
 import 'package:api_client/models/enums/role_enum.dart';
 import 'package:api_client/models/giraf_user_model.dart';
 import 'package:flutter/material.dart';
@@ -14,18 +20,62 @@ import 'package:weekplanner/screens/new_citizen_screen.dart';
 import 'package:weekplanner/widgets/giraf_app_bar_widget.dart';
 import 'package:weekplanner/widgets/giraf_button_widget.dart';
 
+class MockAccountApi extends AccountApi {
+  MockAccountApi(PersistenceClient persist)
+      : super(HttpClient(baseUrl: null, persist: persist), persist);
+
+  @override
+  Observable<GirafUserModel> register(
+      String username, String password, String displayName,
+      {@required int departmentId, @required Role role}) {
+    final Map<String, dynamic> body = <String, dynamic>{
+      'username': username,
+      'displayName': displayName,
+      'password': password,
+      'department': departmentId,
+      'id': '2',
+      'role': 2,
+      'roleName': '' + role.toString().split('.').last,
+    };
+
+    if (username == 'alreadyExists') {
+      final http.Response mockHttpResponse = http.Response(
+          // ignore: lines_longer_than_80_chars
+          'message: User already exists, details: A user with the given username already exists, errorKey: UserAlreadyExists',
+          401);
+      final Observable<Response> mockResponse =
+          Observable<Response>.fromFuture(futureMockResponse(mockHttpResponse));
+      return mockResponse.map((Response res) => throw ApiException(res));
+    }
+    return Observable<GirafUserModel>.fromFuture(createMockUserModel(body));
+  }
+
+  Future<Response> futureMockResponse(http.Response response) async {
+    return Response(response, <String, dynamic>{
+      'message': 'User already exists',
+      'details': 'A user with the given username already exists',
+      'errorKey': 'UserAlreadyExists'
+    });
+  }
+
+  // ignore: missing_return
+  Future<GirafUserModel> createMockUserModel(Map<String, dynamic> body) async {
+    return GirafUserModel.fromJson(body);
+  }
+}
+
+class MockApi extends Api {
+  MockApi(String baseUrl) : super(baseUrl) {
+    account = MockAccountApi(PersistenceClient());
+    user = MockUserApi();
+  }
+}
+
 class MockNewCitizenBloc extends NewCitizenBloc {
   MockNewCitizenBloc(this.api) : super(api);
 
   bool acceptAllInputs = true;
   Api api;
-
-  @override
-  Observable<GirafUserModel> createCitizen() {
-    return api.account
-        .register('mockUserName', 'password', 'mockDisplayName',
-        departmentId: null, role: null);
-  }
 
   @override
   Observable<bool> get validDisplayNameStream =>
@@ -65,7 +115,7 @@ void main() {
   MockNewCitizenBloc mockNewCitizenBloc;
 
   setUp(() {
-    api = Api('any');
+    api = MockApi('any');
     mockNewCitizenBloc = MockNewCitizenBloc(api);
 
     di.clearAll();
@@ -142,5 +192,39 @@ void main() {
             .widget<GirafButton>(find.byKey(const Key('saveButton')))
             .isEnabled,
         isFalse);
+  });
+
+  testWidgets('"Brugernavnet eksisterer allerede" error message',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(home: NewCitizenScreen()));
+    await tester.pump();
+
+    await tester.enterText(
+        find.byKey(const Key('displayNameField')), 'mockDisplayName');
+    await tester.enterText(
+        find.byKey(const Key('usernameField')), 'alreadyExists');
+    await tester.enterText(find.byKey(const Key('passwordField')), 'password');
+    await tester.enterText(
+        find.byKey(const Key('passwordVerifyField')), 'password');
+
+    await tester.tap(find.byKey(const Key('saveButton')));
+    await tester.pumpAndSettle();
+    expect(find.byKey(const Key('ErrorMessageDialog')), findsNWidgets(1));
+  });
+  testWidgets('New user so, no error message should appear',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(home: NewCitizenScreen()));
+    await tester.pump();
+
+    await tester.enterText(
+        find.byKey(const Key('displayNameField')), 'mockDisplayName');
+    await tester.enterText(find.byKey(const Key('usernameField')), 'NewUser');
+    await tester.enterText(find.byKey(const Key('passwordField')), 'password');
+    await tester.enterText(
+        find.byKey(const Key('passwordVerifyField')), 'password');
+
+    await tester.tap(find.byKey(const Key('saveButton')));
+    await tester.pumpAndSettle();
+    expect(find.byKey(const Key('ErrorMessageDialog')), findsNWidgets(0));
   });
 }


### PR DESCRIPTION
Fixes #570 
The class can be expanded with more of the error codes from the ErrorKey class such that it can be used with all communication with the api_client

![image](https://user-images.githubusercontent.com/28717453/94669384-73610e80-0311-11eb-8842-9f7100562542.png)
