### PR TITLE
Releasefix 573: Username validation expanded in new_citizen_bloc.dart

### DIFF
--- a/lib/blocs/new_citizen_bloc.dart
+++ b/lib/blocs/new_citizen_bloc.dart
@@ -100,7 +100,10 @@ class NewCitizenBloc extends BlocBase {
         if (input == null || input.isEmpty) {
           sink.add(false);
         } else {
-          sink.add(!input.contains(' '));
+          //Regular Expression to check if the username contains
+          //only all letters, numbers, underscore and/or hyphen.
+          sink.add(input.contains(RegExp(r'^[A-ZÆØÅ0-9_-]*$',
+            caseSensitive : false)));
         }
       });
 

--- a/lib/screens/new_citizen_screen.dart
+++ b/lib/screens/new_citizen_screen.dart
@@ -61,7 +61,7 @@ class NewCitizenScreen extends StatelessWidget {
                           ? null
                           // cant make it shorter because of the string
                           // ignore: lines_longer_than_80_chars
-                          : 'Brugernavn må ikke indeholde mellemrum eller være tom',
+                          : 'Brugernavn er tom eller indeholder et ugyldigt tegn',
                     ),
                     onChanged: _bloc.onUsernameChange.add,
                   );

--- a/lib/screens/new_citizen_screen.dart
+++ b/lib/screens/new_citizen_screen.dart
@@ -61,7 +61,7 @@ class NewCitizenScreen extends StatelessWidget {
                           ? null
                           // cant make it shorter because of the string
                           // ignore: lines_longer_than_80_chars
-                          : 'Brugernavn er tom eller indeholder et ugyldigt tegn',
+                          : 'Brugernavn er tomt eller indeholder et ugyldigt tegn',
                     ),
                     onChanged: _bloc.onUsernameChange.add,
                   );

--- a/test/blocs/new_citizen_bloc_test.dart
+++ b/test/blocs/new_citizen_bloc_test.dart
@@ -160,6 +160,18 @@ void main() {
     done();
   }));
 
+  test('All inputs are not valid - username', async((DoneFn done) {
+    bloc.onUsernameChange.add('!!PeterMadsen??');
+    bloc.onPasswordChange.add('1234');
+    bloc.onPasswordVerifyChange.add('1234');
+    bloc.onDisplayNameChange.add(user.displayName);
+    bloc.allInputsAreValidStream.listen((bool isValid) {
+      expect(isValid, isNotNull);
+      expect(isValid, false);
+    });
+    done();
+  }));
+
   test('Username validation', async((DoneFn done) {
     bloc.onUsernameChange.add(user.username);
     bloc.validUsernameStream.listen((bool isValid) {


### PR DESCRIPTION
Fixes #573
The _usernamevalidation method has been revised from blacklisting spaces only to a whitelist regex that contains only all letters, ÆØÅ, numbers, underscore( _ ) or a hyphen ( - )

The warning message under the text field has been updated to explain this change.

A test has been added to verify this feature in new_citizen_bloc_test.dart.