### PR TITLE
Feature 535: Buggy "Fortryd" button on activity

### DIFF
--- a/lib/blocs/activity_bloc.dart
+++ b/lib/blocs/activity_bloc.dart
@@ -28,6 +28,10 @@ class ActivityBloc extends BlocBase {
     _user = user;
     _activityModelStream.add(activityModel);
   }
+  /// Return the current ActivityModel
+  ActivityModel getActivity(){
+    return _activityModel;
+  }
 
   /// Mark the selected activity as complete. Toggle function, if activity is
   /// Completed, it will become Normal

--- a/lib/screens/show_activity_screen.dart
+++ b/lib/screens/show_activity_screen.dart
@@ -39,7 +39,7 @@ class ShowActivityScreen extends StatelessWidget {
   }
 
   final DisplayNameModel _girafUser;
-  ActivityModel _activity;
+  final ActivityModel _activity;
 
   final PictogramImageBloc _pictoImageBloc =
       di.getDependency<PictogramImageBloc>();
@@ -228,7 +228,7 @@ class ShowActivityScreen extends StatelessWidget {
                               await Routes.push(context, PictogramSearch())
                                   .then((Object object) {
                                 if (object is PictogramModel) {
-                                  _activityBloc.load(_activity, _girafUser);
+                                  _activityBloc.load(_activity,_girafUser);
                                   final PictogramModel newPictogram = object;
                                   _activity.isChoiceBoard = true;
                                   _activity.pictograms.add(newPictogram);
@@ -632,7 +632,7 @@ class ShowActivityScreen extends StatelessWidget {
                           key: const Key('CancelStateToggleButton'),
                           onPressed: () {
                             _activityBloc.cancelActivity();
-                            _activity = _activityBloc.getActivity();
+                            _activity.state = _activityBloc.getActivity().state;
                           },
                           text: activitySnapshot.data.state !=
                                   ActivityState.Canceled

--- a/lib/screens/show_activity_screen.dart
+++ b/lib/screens/show_activity_screen.dart
@@ -39,7 +39,7 @@ class ShowActivityScreen extends StatelessWidget {
   }
 
   final DisplayNameModel _girafUser;
-  final ActivityModel _activity;
+  ActivityModel _activity;
 
   final PictogramImageBloc _pictoImageBloc =
       di.getDependency<PictogramImageBloc>();
@@ -632,6 +632,7 @@ class ShowActivityScreen extends StatelessWidget {
                           key: const Key('CancelStateToggleButton'),
                           onPressed: () {
                             _activityBloc.cancelActivity();
+                            _activity = _activityBloc.getActivity();
                           },
                           text: activitySnapshot.data.state !=
                                   ActivityState.Canceled

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -37,7 +37,7 @@ packages:
       path: "."
       ref: HEAD
       resolved-ref: "94e216dfc42aa6fca1261d2c7fa4e8b8d054ba3b"
-      url: "https://github.com/ptope/async_test"
+      url: "https://github.com/polytope/async_test"
     source: git
     version: "0.0.1"
   audioplayers:

--- a/test/screens/show_activity_screen_test.dart
+++ b/test/screens/show_activity_screen_test.dart
@@ -862,4 +862,22 @@ void main() {
           findsNothing);
     });
   });
+
+  testWidgets('Activity state is normal when an activity has been cancelled '
+      'and non-cancelled and timer added', (WidgetTester tester) async {
+    authBloc.setMode(WeekplanMode.guardian);
+    mockActivity.state = ActivityState.Normal;
+    await tester.pumpWidget(
+        MaterialApp(home: ShowActivityScreen(mockActivity, mockUser)));
+
+    await tester.pump();
+    await tester.tap(find.byKey(const Key('CancelStateToggleButton')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('CancelStateToggleButton')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('AddTimerButtonKey')));
+    await tester.pumpAndSettle();
+
+    expect(mockActivity.state, ActivityState.Normal);
+  });
 }


### PR DESCRIPTION
The state of the activity is no longer set to final, so it can be updated when the button is pressed and updates correctly both when making a timer and a choice board. 
Fixes #535 