### PR TITLE
Feature 308: Removed red line on finished timer

### DIFF
--- a/lib/widgets/timer_widgets/timer_piechart.dart
+++ b/lib/widgets/timer_widgets/timer_piechart.dart
@@ -24,7 +24,9 @@ class TimerPiechart extends StatelessWidget {
                     side: BorderSide(
                         color: theme.GirafColors.black, width: 0.5))),
             child: CircleAvatar(
-              backgroundColor: theme.GirafColors.red,
+              backgroundColor: timerProgressSnapshot.hasData &&
+                  timerProgressSnapshot.data < 1
+                  ? theme.GirafColors.red : theme.GirafColors.white,
               child: Padding(
                 padding: const EdgeInsets.all(15.0),
                 child: CircularProgressIndicator(


### PR DESCRIPTION
Fixes #308 
The problem seems to be a bug in the CircularProgressIndicator used to indicate the timer. 
The work-around was to change the background from red to white when the is complete.