### PR TITLE
Refactoring of font sizes

### DIFF
--- a/lib/blocs/toolbar_bloc.dart
+++ b/lib/blocs/toolbar_bloc.dart
@@ -8,6 +8,7 @@ import 'package:weekplanner/di.dart';
 import 'package:weekplanner/models/enums/app_bar_icons_enum.dart';
 import 'package:weekplanner/models/enums/weekplan_mode.dart';
 import 'package:weekplanner/routes.dart';
+import 'package:weekplanner/style/font_size.dart';
 import 'package:weekplanner/widgets/giraf_confirm_dialog.dart';
 import 'package:weekplanner/widgets/giraf_notify_dialog.dart';
 import 'package:weekplanner/widgets/loading_spinner_widget.dart';
@@ -275,7 +276,8 @@ class ToolbarBloc extends BlocBase {
                 : null,
             child: const Text(
               'Bekræft',
-              style: TextStyle(color: theme.GirafColors.white, fontSize: 20),
+              style: TextStyle(color: theme.GirafColors.white,
+                  fontSize: GirafFont.small),
             ),
             color: theme.GirafColors.dialogButton,
           )

--- a/lib/screens/choose_citizen_screen.dart
+++ b/lib/screens/choose_citizen_screen.dart
@@ -9,6 +9,7 @@ import 'package:weekplanner/screens/new_citizen_screen.dart';
 import 'package:weekplanner/screens/weekplan_selector_screen.dart';
 import 'package:weekplanner/widgets/citizen_avatar_widget.dart';
 import 'package:weekplanner/widgets/giraf_app_bar_widget.dart';
+import 'package:weekplanner/style/font_size.dart';
 
 /// The screen to choose a citizen
 class ChooseCitizenScreen extends StatefulWidget {
@@ -127,7 +128,7 @@ class _ChooseCitizenScreenState extends State<ChooseCitizenScreen> {
                 child: const Center(
                   child: AutoSizeText(
                     'Tilføj Borger',
-                    style: TextStyle(fontSize: 30),
+                    style: TextStyle(fontSize: GirafFont.large),
                   ),
                 )
             )

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -4,6 +4,7 @@ import 'package:weekplanner/blocs/auth_bloc.dart';
 import 'package:weekplanner/di.dart';
 import 'package:weekplanner/providers/environment_provider.dart' as environment;
 import 'package:weekplanner/routes.dart';
+import 'package:weekplanner/style/font_size.dart';
 import 'package:weekplanner/widgets/giraf_notify_dialog.dart';
 import 'package:weekplanner/widgets/loading_spinner_widget.dart';
 import 'package:http/http.dart' as http;
@@ -145,7 +146,7 @@ class LoginScreenState extends State<LoginScreen> {
                         padding: const EdgeInsets.fromLTRB(8.0, 8.0, 8.0, 8.0),
                         child: TextField(
                           key: const Key('UsernameKey'),
-                          style: const TextStyle(fontSize: 30),
+                          style: const TextStyle(fontSize: GirafFont.large),
                           controller: usernameCtrl,
                           keyboardType: TextInputType.text,
                           // Use email input type for emails.
@@ -170,7 +171,7 @@ class LoginScreenState extends State<LoginScreen> {
                         padding: const EdgeInsets.all(8.0),
                         child: TextField(
                           key: const Key('PasswordKey'),
-                          style: const TextStyle(fontSize: 30),
+                          style: const TextStyle(fontSize: GirafFont.large),
                           controller: passwordCtrl,
                           obscureText: true,
                           decoration: const InputDecoration.collapsed(

--- a/lib/screens/settings_screens/privacy_information_screen.dart
+++ b/lib/screens/settings_screens/privacy_information_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:weekplanner/style/custom_color.dart' as theme;
+import 'package:weekplanner/style/font_size.dart';
 import 'package:weekplanner/widgets/giraf_app_bar_widget.dart';
 
 /// Screen where the user see their legal rights
@@ -25,12 +26,12 @@ class PrivacyInformationScreen extends StatelessWidget {
                           TextSpan(
                               text: 'Oplysninger om vores behandling '
                                   'af dine personoplysninger mv.''\n' '\n',
-                              style: TextStyle(fontSize: 20.0,
+                              style: TextStyle(fontSize: GirafFont.small,
                                   fontWeight: FontWeight.bold)),
                           TextSpan(
                               text: '1. Vi er den dataansvarlige '
                                   '– hvordan kontakter du os?' '\n' '\n',
-                              style: TextStyle(fontSize: 30.00,
+                              style: TextStyle(fontSize: GirafFont.large,
                               fontWeight: FontWeight.bold)),
                           TextSpan(
                               text: 'Girafs Venner er dataansvarlig for '
@@ -49,12 +50,12 @@ class PrivacyInformationScreen extends StatelessWidget {
                                   '\n' '\n'
                                   '   \u2022 '
                                   'Mail: ulrik@cs.aau.dk' '\n' '\n',
-                              style: TextStyle(fontSize: 20.0)),
+                              style: TextStyle(fontSize: GirafFont.small)),
                           TextSpan(
                               text: '2. Formålene med og retsgrundlaget for '
                                   'behandlingen af dine '
                                   'personoplysninger' '\n' '\n',
-                              style: TextStyle(fontSize: 30.0,
+                              style: TextStyle(fontSize: GirafFont.small,
                                   fontWeight: FontWeight.bold)),
                           TextSpan(
                               text: 'Vi behandler dine '
@@ -96,11 +97,11 @@ class PrivacyInformationScreen extends StatelessWidget {
                                   'struktur i hverdagen gennem '
                                   'et kommunikationsværktøj.' '\n'
                                   '\n',
-                              style: TextStyle(fontSize: 20.0)),
+                              style: TextStyle(fontSize: GirafFont.small)),
                           TextSpan(
                               text: '3. Kategorier af '
                                   'personoplysninger' '\n' '\n',
-                              style: TextStyle(fontSize: 30.0,
+                              style: TextStyle(fontSize: GirafFont.large,
                                   fontWeight: FontWeight.bold)),
                           TextSpan(
                               text: 'Vi behandler følgende '
@@ -111,23 +112,23 @@ class PrivacyInformationScreen extends StatelessWidget {
                                   '   \u2022 ' 'Almindelige '
                                   'personoplysninger'
                                   '\n' '\n',
-                              style: TextStyle(fontSize: 20.0)),
+                              style: TextStyle(fontSize: GirafFont.small)),
                           TextSpan(
                               text: '4. Hvor dine '
                                   'personoplysninger stammer '
                                   'fra' '\n' '\n',
-                              style: TextStyle(fontSize: 30.0,
+                              style: TextStyle(fontSize: GirafFont.large,
                                   fontWeight: FontWeight.bold)),
                           TextSpan(
                               text: 'Personoplysningerne stammer '
                                   'fra registreringen af brugeren '
                                   'i applikationen.' '\n' '\n',
-                              style: TextStyle(fontSize: 20.0)),
+                              style: TextStyle(fontSize: GirafFont.small)),
                           TextSpan(
                               text: '5. Opbevaring af '
                                   'dine personoplysninger' '\n'
                                   '\n',
-                              style: TextStyle(fontSize: 30.0,
+                              style: TextStyle(fontSize: GirafFont.large,
                                   fontWeight: FontWeight.bold)),
                           TextSpan(
                               text: 'Personlige oplysninger '
@@ -139,12 +140,12 @@ class PrivacyInformationScreen extends StatelessWidget {
                                   'institutionen eller som resultat '
                                   'af manglende anvendelse af '
                                   'systemet.' '\n' '\n',
-                              style: TextStyle(fontSize: 20.0)),
+                              style: TextStyle(fontSize: GirafFont.small)),
                           TextSpan(
                               text: '6. Retten til at '
                                   'trække samtykke tilbage'
                                   '\n' '\n',
-                              style: TextStyle(fontSize: 30.0,
+                              style: TextStyle(fontSize: GirafFont.large,
                                   fontWeight: FontWeight.bold)),
                           TextSpan(
                               text: 'Du har til enhver tid ret '
@@ -163,9 +164,9 @@ class PrivacyInformationScreen extends StatelessWidget {
                                   ' dit samtykke, har det '
                                   'derfor først virkning '
                                   'fra dette tidspunkt.' '\n' '\n',
-                              style: TextStyle(fontSize: 20.0)),
+                              style: TextStyle(fontSize: GirafFont.small)),
                           TextSpan(text: '7. Dine rettigheder' '\n' '\n',
-                              style: TextStyle(fontSize: 30.0,
+                              style: TextStyle(fontSize: GirafFont.large,
                                   fontWeight: FontWeight.bold)),
                           TextSpan(
                               text: 'Du har efter '
@@ -190,7 +191,7 @@ class PrivacyInformationScreen extends StatelessWidget {
                                   'Du har ret til at få urigtige '
                                   'oplysninger om dig selv '
                                   'rettet.' '\n' '\n',
-                              style: TextStyle(fontSize: 20.0)),
+                              style: TextStyle(fontSize: GirafFont.small)),
                           TextSpan(
                               text: '   \u2022 '
                                   'Ret til sletning. I særlige'
@@ -244,10 +245,10 @@ class PrivacyInformationScreen extends StatelessWidget {
                                   'registreredes rettigheder, '
                                   'som du finder på '
                                   'www.datatilsynet.dk.' '\n' '\n',
-                              style: TextStyle(fontSize: 20.0)),
+                              style: TextStyle(fontSize: GirafFont.small)),
                           TextSpan(text: '8. Klage til Datatilsynet'
                               '\n' '\n',
-                              style: TextStyle(fontSize: 30.0,
+                              style: TextStyle(fontSize: GirafFont.large,
                                   fontWeight: FontWeight.bold)),
                           TextSpan(
                               text: 'Du har ret til at '
@@ -258,7 +259,7 @@ class PrivacyInformationScreen extends StatelessWidget {
                                   'Du finder Datatilsynets '
                                   'kontaktoplysninger på '
                                   'www.datatilsynet.dk.' '\n' '\n',
-                              style: TextStyle(fontSize: 20.0)),
+                              style: TextStyle(fontSize: GirafFont.small)),
 
 
                         ],

--- a/lib/screens/show_activity_screen.dart
+++ b/lib/screens/show_activity_screen.dart
@@ -16,6 +16,7 @@ import 'package:weekplanner/models/enums/timer_running_mode.dart';
 import 'package:weekplanner/models/enums/weekplan_mode.dart';
 import 'package:weekplanner/routes.dart';
 import 'package:weekplanner/screens/pictogram_search_screen.dart';
+import 'package:weekplanner/style/font_size.dart';
 import 'package:weekplanner/widgets/choiceboard_widgets/choice_board.dart';
 import 'package:weekplanner/widgets/giraf_activity_time_picker_dialog.dart';
 import 'package:weekplanner/widgets/giraf_app_bar_widget.dart';
@@ -49,7 +50,8 @@ class ShowActivityScreen extends StatelessWidget {
   final AuthBloc _authBloc = di.getDependency<AuthBloc>();
 
   /// Text style used for title.
-  final TextStyle titleTextStyle = const TextStyle(fontSize: 24);
+  final TextStyle titleTextStyle = const TextStyle(fontSize:
+  GirafFont.activity_screen_buttons);
 
   @override
   Widget build(BuildContext context) {

--- a/lib/screens/upload_image_from_phone_screen.dart
+++ b/lib/screens/upload_image_from_phone_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter/widgets.dart';
 import 'package:weekplanner/blocs/upload_from_gallery_bloc.dart';
 import 'package:weekplanner/di.dart';
 import 'package:weekplanner/routes.dart';
+import 'package:weekplanner/style/font_size.dart';
 import 'package:weekplanner/widgets/giraf_app_bar_widget.dart';
 import 'package:weekplanner/widgets/giraf_button_widget.dart';
 import 'package:weekplanner/widgets/giraf_notify_dialog.dart';
@@ -168,7 +169,8 @@ class UploadImageFromPhone extends StatelessWidget {
         ),
         const Text(
           'Tryk for at vælge billede',
-          style: TextStyle(color: theme.GirafColors.black, fontSize: 25),
+          style: TextStyle(color: theme.GirafColors.black,
+              fontSize: GirafFont.medium),
         )
       ],
     );
@@ -181,7 +183,8 @@ class UploadImageFromPhone extends StatelessWidget {
         ),
         child: Text(
           'Vælg billede fra galleri',
-          style: TextStyle(color: theme.GirafColors.black, fontSize: 25),
+          style: TextStyle(color: theme.GirafColors.black,
+              fontSize: GirafFont.medium),
           textAlign: TextAlign.center,
         ));
   }

--- a/lib/screens/weekplan_selector_screen.dart
+++ b/lib/screens/weekplan_selector_screen.dart
@@ -14,6 +14,7 @@ import 'package:weekplanner/screens/edit_weekplan_screen.dart';
 import 'package:weekplanner/screens/new_weekplan_screen.dart';
 import 'package:weekplanner/screens/settings_screens/settings_screen.dart';
 import 'package:weekplanner/screens/weekplan_screen.dart';
+import 'package:weekplanner/style/font_size.dart';
 import 'package:weekplanner/widgets/bottom_app_bar_button_widget.dart';
 import 'package:weekplanner/widgets/giraf_3button_dialog.dart';
 import 'package:weekplanner/widgets/giraf_app_bar_widget.dart';
@@ -74,7 +75,7 @@ class WeekplanSelectorScreen extends StatelessWidget {
         child:
           const AutoSizeText(
             'Overståede uger',
-            style: TextStyle(fontSize: 18),
+            style: TextStyle(fontSize: GirafFont.small),
             maxLines: 1,
             minFontSize: 14,
             textAlign: TextAlign.center,
@@ -188,7 +189,7 @@ class WeekplanSelectorScreen extends StatelessWidget {
                         (BuildContext context, BoxConstraints constraints) {
                       return AutoSizeText(
                         weekplan.name,
-                        style: const TextStyle(fontSize: 18),
+                        style: const TextStyle(fontSize: GirafFont.small),
                         maxLines: 1,
                         minFontSize: 14,
                         textAlign: TextAlign.center,
@@ -205,7 +206,7 @@ class WeekplanSelectorScreen extends StatelessWidget {
                                 'Uge: ${weekplan.weekNumber}      '
                                 'År: ${weekplan.weekYear}',
                                 key: const Key('weekYear'),
-                                style: const TextStyle(fontSize: 18),
+                                style: const TextStyle(fontSize: GirafFont.small),
                                 maxLines: 1,
                                 minFontSize: 14,
                                 textAlign: TextAlign.center,

--- a/lib/screens/weekplan_selector_screen.dart
+++ b/lib/screens/weekplan_selector_screen.dart
@@ -206,7 +206,8 @@ class WeekplanSelectorScreen extends StatelessWidget {
                                 'Uge: ${weekplan.weekNumber}      '
                                 'År: ${weekplan.weekYear}',
                                 key: const Key('weekYear'),
-                                style: const TextStyle(fontSize: GirafFont.small),
+                                style: const TextStyle(fontSize:
+                                GirafFont.small),
                                 maxLines: 1,
                                 minFontSize: 14,
                                 textAlign: TextAlign.center,

--- a/lib/style/font_size.dart
+++ b/lib/style/font_size.dart
@@ -1,6 +1,4 @@
-import 'package:flutter/material.dart';
-
-/// Font sizes for the GIRAF project.
+s/// Font sizes for the GIRAF project.
 
 class GirafFont
 {

--- a/lib/style/font_size.dart
+++ b/lib/style/font_size.dart
@@ -1,4 +1,4 @@
-s/// Font sizes for the GIRAF project.
+/// Font sizes for the GIRAF project.
 
 class GirafFont
 {

--- a/lib/style/font_size.dart
+++ b/lib/style/font_size.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+/// Font sizes for the GIRAF project.
+
+class GirafFont
+{
+  GirafFont._();
+
+  static const double pictogram = 150;
+  static const double timer = 50;
+  static const double large = 30;
+  static const double small = 20;
+  static const double medium = 24;
+  static const double activity_screen_buttons = 23;
+
+
+}

--- a/lib/widgets/citizen_avatar_widget.dart
+++ b/lib/widgets/citizen_avatar_widget.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 import 'package:api_client/models/displayname_model.dart';
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
+import 'package:weekplanner/style/font_size.dart';
 
 /// Citizen avatar used for choose citizen screen
 class CitizenAvatar extends StatelessWidget {
@@ -65,7 +66,8 @@ class CitizenAvatar extends StatelessWidget {
                                                     .substring(0, 14) + '..',
                               key: const Key('WidgetText'),
                               style:
-                              TextStyle(fontSize: _isTablet(query) ? 30.0 : 20),
+                              TextStyle(fontSize: _isTablet(query) ?
+                              GirafFont.large : GirafFont.small),
                             ),
                           ),
                         )

--- a/lib/widgets/giraf_activity_time_picker_dialog.dart
+++ b/lib/widgets/giraf_activity_time_picker_dialog.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:weekplanner/blocs/timer_bloc.dart';
 import 'package:weekplanner/routes.dart';
+import 'package:weekplanner/style/font_size.dart';
 import 'package:weekplanner/widgets/giraf_button_widget.dart';
 import 'package:weekplanner/widgets/giraf_notify_dialog.dart';
 import 'package:weekplanner/widgets/giraf_title_header.dart';
@@ -116,7 +117,7 @@ class GirafActivityTimerPickerDialog extends StatelessWidget {
                   },
                   controller: textController,
                   style: const TextStyle(
-                    fontSize: 50,
+                    fontSize: GirafFont.timer,
                   ),
                   textAlign: TextAlign.center,
                   keyboardType: const TextInputType.numberWithOptions(

--- a/lib/widgets/input_fields_weekplan.dart
+++ b/lib/widgets/input_fields_weekplan.dart
@@ -6,6 +6,7 @@ import 'package:weekplanner/blocs/new_weekplan_bloc.dart';
 import 'package:weekplanner/routes.dart';
 import 'package:weekplanner/screens/pictogram_search_screen.dart';
 import 'package:weekplanner/style/custom_color.dart';
+import 'package:weekplanner/style/font_size.dart';
 import 'package:weekplanner/widgets/pictogram_image.dart';
 
 import 'giraf_button_widget.dart';
@@ -33,7 +34,7 @@ class InputFieldsWeekPlan extends StatefulWidget {
 
 /// The state for the input fields
 class InputFieldsWeekPlanState extends State<InputFieldsWeekPlan> {
-  final TextStyle _style = const TextStyle(fontSize: 20);
+  final TextStyle _style = const TextStyle(fontSize: GirafFont.small);
 
   @override
   Widget build(BuildContext context) {

--- a/lib/widgets/pictogram_text.dart
+++ b/lib/widgets/pictogram_text.dart
@@ -8,6 +8,7 @@ import 'package:weekplanner/blocs/auth_bloc.dart';
 import 'package:weekplanner/blocs/settings_bloc.dart';
 import 'package:weekplanner/di.dart';
 import 'package:weekplanner/models/enums/weekplan_mode.dart';
+import 'package:weekplanner/style/font_size.dart';
 
 /// This is a widget used to create text under the pictograms
 class PictogramText extends StatelessWidget {
@@ -78,7 +79,8 @@ class PictogramText extends StatelessWidget {
             textAlign: TextAlign.center,
             // creates a ... postfix if text overflows
             overflow: TextOverflow.ellipsis,
-            style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 150),
+            style: const TextStyle(fontWeight: FontWeight.bold,
+                fontSize: GirafFont.pictogram),
           ),
         ));
   }


### PR DESCRIPTION
Font sizes now have a document where they are defined. There was used a font size of 25 twice in upload_image_from_phone_screen which has been set to 24 so it's the same as the other places. Likewise the font size was set to 18 in weekplan_selector_screen and it's been set to 20 as in line with the rest of the app.

I have not written any tests for this refactoring, since there are no new widgets nor methods to test. 

Closes #438 