### PR TITLE
Feature/529: Guardians should be able to mark activities as complete like the citizens can

### DIFF
--- a/lib/screens/show_activity_screen.dart
+++ b/lib/screens/show_activity_screen.dart
@@ -631,7 +631,8 @@ class ShowActivityScreen extends StatelessWidget {
                     }
                     if (weekplanModeSnapshot.data == WeekplanMode.guardian) {
                       return Container(
-                        child: Column(children: <Widget>[
+                        child: Row(children: <Widget>[
+                        Container(child:
                         GirafButton(
                         key: const Key('CancelStateToggleButton'),
                           onPressed: () {
@@ -643,17 +644,19 @@ class ShowActivityScreen extends StatelessWidget {
                               ? 'Aflys'
                               : 'Fortryd',
                           icon: activitySnapshot.data.state !=
-                              ActivityState.Canceled
+                                  ActivityState.Canceled
                               ? const ImageIcon(
-                              AssetImage('assets/icons/cancel.png'),
-                              color: theme.GirafColors.red)
+                                  AssetImage('assets/icons/cancel.png'),
+                                  color: theme.GirafColors.red)
                               : const ImageIcon(
-                              AssetImage('assets/icons/undo.png'),
-                              color: theme.GirafColors.blue)
+                                  AssetImage('assets/icons/undo.png'),
+                                  color: theme.GirafColors.blue),
                         ),
-                        const SizedBox(height: 3.5),
+                        margin: const EdgeInsets.only(right: 40.0)
+                        ),
+                        Container(child:
                         GirafButton(
-                          key: const Key('CompleteStateToggleButton'),
+                        key: const Key('CompleteStateToggleButton'),
                           onPressed: () {
                             _activityBloc.completeActivity();
                           },
@@ -669,8 +672,9 @@ class ShowActivityScreen extends StatelessWidget {
                                   AssetImage('assets/icons/undo.png'),
                                   color: theme.GirafColors.blue)
                         ),
-                        ]),
-                      );
+                        margin: const EdgeInsets.only(left: 40.0),
+                        ),
+                    ]));
 
                     } else {
                       return GirafButton(

--- a/lib/screens/show_activity_screen.dart
+++ b/lib/screens/show_activity_screen.dart
@@ -217,7 +217,7 @@ class ShowActivityScreen extends StatelessWidget {
                         child: AspectRatio(
                           aspectRatio: 1,
                           child: IconButton(
-                            icon: AspectRatio(
+                            icon: const AspectRatio(
                               aspectRatio: 1,
                               child: FittedBox(
                                 child: Icon(
@@ -632,8 +632,9 @@ class ShowActivityScreen extends StatelessWidget {
                     if (weekplanModeSnapshot.data == WeekplanMode.guardian) {
                       return Container(
                         child: Row(children: <Widget>[
-                        Container(child:
-                        GirafButton(
+                          Padding(
+                        padding: const EdgeInsets.only(right: 40.0),
+                        child: GirafButton(
                         key: const Key('CancelStateToggleButton'),
                           onPressed: () {
                             _activityBloc.cancelActivity();
@@ -651,10 +652,7 @@ class ShowActivityScreen extends StatelessWidget {
                               : const ImageIcon(
                                   AssetImage('assets/icons/undo.png'),
                                   color: theme.GirafColors.blue),
-                        ),
-                        margin: const EdgeInsets.only(right: 40.0)
-                        ),
-                        Container(child:
+                        )),
                         GirafButton(
                         key: const Key('CompleteStateToggleButton'),
                           onPressed: () {
@@ -671,8 +669,6 @@ class ShowActivityScreen extends StatelessWidget {
                               : const ImageIcon(
                                   AssetImage('assets/icons/undo.png'),
                                   color: theme.GirafColors.blue)
-                        ),
-                        margin: const EdgeInsets.only(left: 40.0),
                         ),
                     ]));
 

--- a/lib/screens/show_activity_screen.dart
+++ b/lib/screens/show_activity_screen.dart
@@ -630,24 +630,48 @@ class ShowActivityScreen extends StatelessWidget {
                       return const CircularProgressIndicator();
                     }
                     if (weekplanModeSnapshot.data == WeekplanMode.guardian) {
-                      return GirafButton(
-                          key: const Key('CancelStateToggleButton'),
+                      return Container(
+                        child: Column(children: <Widget>[
+                        GirafButton(
+                        key: const Key('CancelStateToggleButton'),
                           onPressed: () {
                             _activityBloc.cancelActivity();
                             _activity.state = _activityBloc.getActivity().state;
                           },
                           text: activitySnapshot.data.state !=
-                                  ActivityState.Canceled
+                              ActivityState.Canceled
                               ? 'Aflys'
                               : 'Fortryd',
                           icon: activitySnapshot.data.state !=
-                                  ActivityState.Canceled
+                              ActivityState.Canceled
                               ? const ImageIcon(
-                                  AssetImage('assets/icons/cancel.png'),
-                                  color: theme.GirafColors.red)
+                              AssetImage('assets/icons/cancel.png'),
+                              color: theme.GirafColors.red)
+                              : const ImageIcon(
+                              AssetImage('assets/icons/undo.png'),
+                              color: theme.GirafColors.blue)
+                        ),
+                        const SizedBox(height: 3.5),
+                        GirafButton(
+                          key: const Key('CompleteStateToggleButton'),
+                          onPressed: () {
+                            _activityBloc.completeActivity();
+                          },
+                          isEnabled: activitySnapshot.data.state !=
+                              ActivityState.Canceled,
+                          width: 100,
+                          icon: activitySnapshot.data.state !=
+                                  ActivityState.Completed
+                              ? const ImageIcon(
+                                  AssetImage('assets/icons/accept.png'),
+                                  color: theme.GirafColors.green)
                               : const ImageIcon(
                                   AssetImage('assets/icons/undo.png'),
-                                  color: theme.GirafColors.blue));
+                                  color: theme.GirafColors.blue)
+                        ),
+                        ]),
+                      );
+
                     } else {
                       return GirafButton(
                           key: const Key('CompleteStateToggleButton'),

--- a/test/screens/show_activity_screen_test.dart
+++ b/test/screens/show_activity_screen_test.dart
@@ -298,14 +298,14 @@ void main() {
     expect(find.byKey(const Key('CancelStateToggleButton')), findsOneWidget);
   });
 
-  testWidgets('Complete activity button is NOT rendered in guardian mode',
+  testWidgets('Complete activity button is rendered in guardian mode',
       (WidgetTester tester) async {
     authBloc.setMode(WeekplanMode.guardian);
     await tester.pumpWidget(
         MaterialApp(home: ShowActivityScreen(mockActivity, mockUser)));
     await tester.pump();
 
-    expect(find.byKey(const Key('CompleteStateToggleButton')), findsNothing);
+    expect(find.byKey(const Key('CompleteStateToggleButton')), findsOneWidget);
   });
 
   testWidgets('Cancel activity button is NOT rendered in citizen mode',


### PR DESCRIPTION
Rendered complete activity button if user is a guardian.
Widget tests if the button is rendered.

closes #529 