### PR TITLE
Feature/364: Minimum Android APK version changed from 16 (Jelly Bean) to 23 (Marshmallow)

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -61,7 +61,7 @@ android {
 
     defaultConfig {
         applicationId "dk.aau.cs.giraf.weekplanner"
-        minSdkVersion 16
+        minSdkVersion 23
         targetSdkVersion 29
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName


### PR DESCRIPTION
Closes #364.

minSdkVersion has been increased from 16 to 23, primarily to prevent a library warning with text relocations.

The warning seemed to be limited to either APK versions 19/21 and lower, thus by unsupporting them, no warnings will be issued.