### PR TITLE
Feature/583: When deleting the left-most option in a choiceboard the wrong picture is shown

### DIFF
--- a/lib/screens/show_activity_screen.dart
+++ b/lib/screens/show_activity_screen.dart
@@ -187,7 +187,7 @@ class ShowActivityScreen extends StatelessWidget {
               child: AspectRatio(
                 aspectRatio: 1,
                 child: Padding(
-                  padding: const EdgeInsets.all(20),  
+                  padding: const EdgeInsets.all(20),
                   child: Card(
                     key: const Key('AddChoiceBoardButtonKey'),
                     child: InkWell(
@@ -283,7 +283,7 @@ class ShowActivityScreen extends StatelessWidget {
                                   _buildTimerDialog(overallContext) : null;
                                   },
                                 //hide splash/highlight color when timer exists
-                                highlightColor: timerInitSnapshot.data == null 
+                                highlightColor: timerInitSnapshot.data == null
                                   || !timerInitSnapshot.data ?
                                   Theme.of(overallContext).highlightColor :
                                   Colors.transparent,
@@ -311,7 +311,7 @@ class ShowActivityScreen extends StatelessWidget {
                                       ? _timerIsInitiatedWidget()
                                       : _timerIsNotInitiatedWidget(
                                         overallContext, modeSnapshot)),
-                                      _timerButtons(overallContext, 
+                                      _timerButtons(overallContext,
                                       timerInitSnapshot, modeSnapshot)
                                 ]
                               ),
@@ -356,7 +356,8 @@ class ShowActivityScreen extends StatelessWidget {
                                 child: _activity.isChoiceBoard
                                     ? ChoiceBoard(
                                         _activity, _activityBloc, _girafUser)
-                                    : buildLoadPictogramImage(),
+                                    : buildLoadPictogramImage()
+
                               ),
                               _buildActivityStateIcon(
                                   context, snapshot.data.state),
@@ -416,7 +417,7 @@ class ShowActivityScreen extends StatelessWidget {
               padding: const EdgeInsets.all(0),
               child: Container(
                   child: const ImageIcon(AssetImage('assets/icons/addTimerHighRes.png')),
-                  key: const Key('AddTimerButtonKey'),                     
+                  key: const Key('AddTimerButtonKey'),
             )))
         : Container(
             key: const Key('TimerNotInitCitizenKey'),
@@ -711,6 +712,7 @@ class ShowActivityScreen extends StatelessWidget {
 
   /// Creates a pictogram image from the streambuilder
   Widget buildLoadPictogramImage() {
+    _pictoImageBloc.load(_activityBloc.getActivity().pictograms.first);
     return StreamBuilder<Image>(
       stream: _pictoImageBloc.image,
       builder: (BuildContext context, AsyncSnapshot<Image> snapshot) {


### PR DESCRIPTION
One line of code was added to the buildLoadPictogramImage widget in the file show_activity_screen.dart. The first pictogram of the activity in the activity bloc is loaded to the pictogram image bloc. This then updates the activity screen with the correct pictogram(s), when deleting another pictogram from the choiceboard.
No tests was implemented for this issue because there currently doesn't exist any tests for choiceboards. Not a single functionality for the choiceboard is being widget tested, and this issue does not require test for all functionalities of choiceboards. Instead, another issue has been created for implementing choiceboard tests.

closes #583
 