### PR TITLE
feature/696: Inconsistent buttons

### DIFF
--- a/lib/screens/show_activity_screen.dart
+++ b/lib/screens/show_activity_screen.dart
@@ -117,7 +117,8 @@ class ShowActivityScreen extends StatelessWidget {
           builder: (BuildContext context,
               AsyncSnapshot<ActivityModel> activitySnapshot) {
             return (activitySnapshot.hasData &&
-                    activitySnapshot.data.state == ActivityState.Canceled)
+                   (activitySnapshot.data.state == ActivityState.Canceled ||
+                    activitySnapshot.data.state == ActivityState.Completed))
                 ? _resetTimerAndBuildEmptyContainer()
                 : _buildTimer(context);
           }),
@@ -134,7 +135,7 @@ class ShowActivityScreen extends StatelessWidget {
                 if (authSnapshot.hasData &&
                     activitySnapshot.hasData &&
                     authSnapshot.data != WeekplanMode.citizen &&
-                    activitySnapshot.data.state != ActivityState.Canceled) {
+                    activitySnapshot.data.state == ActivityState.Normal) {
                   return _buildChoiceBoardButton(context);
                 } else {
                   return _buildEmptyContainer();
@@ -654,6 +655,8 @@ class ShowActivityScreen extends StatelessWidget {
                             _activityBloc.cancelActivity();
                             _activity.state = _activityBloc.getActivity().state;
                           },
+                          isEnabled: activitySnapshot.data.state !=
+                              ActivityState.Completed,
                           text: activitySnapshot.data.state !=
                               ActivityState.Canceled
                               ? 'Aflys'

--- a/lib/screens/show_activity_screen.dart
+++ b/lib/screens/show_activity_screen.dart
@@ -135,7 +135,8 @@ class ShowActivityScreen extends StatelessWidget {
                 if (authSnapshot.hasData &&
                     activitySnapshot.hasData &&
                     authSnapshot.data != WeekplanMode.citizen &&
-                    activitySnapshot.data.state == ActivityState.Normal) {
+                    (activitySnapshot.data.state != ActivityState.Canceled &&
+                    activitySnapshot.data.state != ActivityState.Completed)) {
                   return _buildChoiceBoardButton(context);
                 } else {
                   return _buildEmptyContainer();


### PR DESCRIPTION
Only partly solved the issue.
The buttons now correctly remove the timer and add choiceboard options when marking an activity as completed as well as cancelled. Furthermore an isEnabled has been added to the cancel button, so it becomes disables when the state is completed.
The buttons however only become disabled, when you reenter the activity. This is due to the fact the other button does not check for a new state, when the first button is pressed and as such does not get the new state information, when an acitivty is completed or cancelled. There is not enough time to fix this before release, and as such only the most system breaking part of the bug has been fixed, as it would do some funky things, when trying to make a choiceboard on a completed activity.

relates to weekplanner issue #696 