### PR TITLE
feature 680: Implemented button for switching between citizen view and guardian view from activity screen

### DIFF
--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -123,7 +123,6 @@ class LoginScreenState extends State<LoginScreen> {
     final bool keyboard = MediaQuery.of(context).viewInsets.bottom > 0;
 
     return Scaffold(
-      resizeToAvoidBottomPadding: false,
       body: Container(
         width: screenSize.width,
         height: screenSize.height,

--- a/lib/screens/show_activity_screen.dart
+++ b/lib/screens/show_activity_screen.dart
@@ -91,7 +91,14 @@ class ShowActivityScreen extends StatelessWidget {
         resizeToAvoidBottomInset: false,
         appBar: GirafAppBar(
             title: 'Aktivitet',
-            appBarIcons: const <AppBarIcon, VoidCallback>{}),
+            appBarIcons: (mode == WeekplanMode.guardian)
+            ? <AppBarIcon, VoidCallback>{
+                AppBarIcon.changeToCitizen: () {}
+            }
+            : <AppBarIcon, VoidCallback>{
+                AppBarIcon.changeToGuardian: () {}
+            },
+        ),
         body: childContainer);
   }
 

--- a/lib/screens/weekplan_selector_screen.dart
+++ b/lib/screens/weekplan_selector_screen.dart
@@ -56,6 +56,7 @@ class WeekplanSelectorScreen extends StatefulWidget {
         appBar: GirafAppBar(
           title: widget._user.displayName,
           appBarIcons: <AppBarIcon, VoidCallback>{
+            AppBarIcon.changeToCitizen: () {},
             AppBarIcon.edit: () => widget._weekBloc.toggleEditMode(),
             AppBarIcon.logout: () {},
             AppBarIcon.settings: () =>


### PR DESCRIPTION
closes #680