### PR TITLE
Feature 700: Added switch to citizen button on weekplan selector screen

### DIFF
--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -123,7 +123,6 @@ class LoginScreenState extends State<LoginScreen> {
     final bool keyboard = MediaQuery.of(context).viewInsets.bottom > 0;
 
     return Scaffold(
-      resizeToAvoidBottomPadding: false,
       body: Container(
         width: screenSize.width,
         height: screenSize.height,

--- a/lib/screens/weekplan_selector_screen.dart
+++ b/lib/screens/weekplan_selector_screen.dart
@@ -56,8 +56,8 @@ class WeekplanSelectorScreen extends StatefulWidget {
         appBar: GirafAppBar(
           title: widget._user.displayName,
           appBarIcons: <AppBarIcon, VoidCallback>{
-            AppBarIcon.changeToCitizen: () {},
             AppBarIcon.edit: () => widget._weekBloc.toggleEditMode(),
+            AppBarIcon.changeToCitizen: () {},
             AppBarIcon.logout: () {},
             AppBarIcon.settings: () =>
                 Routes.push(context, SettingsScreen(widget._user))

--- a/lib/screens/weekplan_selector_screen.dart
+++ b/lib/screens/weekplan_selector_screen.dart
@@ -56,6 +56,7 @@ class WeekplanSelectorScreen extends StatefulWidget {
         appBar: GirafAppBar(
           title: widget._user.displayName,
           appBarIcons: <AppBarIcon, VoidCallback>{
+            AppBarIcon.changeToCitizen: () {},
             AppBarIcon.edit: () => widget._weekBloc.toggleEditMode(),
             AppBarIcon.logout: () {},
             AppBarIcon.settings: () =>


### PR DESCRIPTION
The button switches the user to Citizen mode but there is no visual change as a citizen has no special screen for the overall weekplan. The citizen is therefore still able to select and add different weekplans until one has entered a weekplan. closes #700 