### PR TITLE
Task/901

### DIFF
--- a/lib/blocs/take_image_with_camera_bloc.dart
+++ b/lib/blocs/take_image_with_camera_bloc.dart
@@ -95,7 +95,7 @@ class TakePictureWithCameraBloc extends BlocBase {
     _isUploading.add(true);
     return _api.pictogram
         .create(PictogramModel(
-      accessLevel: _accessLevel,
+      accessLevel: AccessLevel.PRIVATE,
       title: _pictogramName,
     ))
         .flatMap((PictogramModel pictogram) {

--- a/lib/blocs/take_image_with_camera_bloc.dart
+++ b/lib/blocs/take_image_with_camera_bloc.dart
@@ -36,8 +36,6 @@ class TakePictureWithCameraBloc extends BlocBase {
   final rx_dart.BehaviorSubject<bool> _isUploading =
   rx_dart.BehaviorSubject<bool>.seeded(false);
 
-  AccessLevel _accessLevel = AccessLevel.PUBLIC;
-
   /// pushes an imagePicker screen, then sets the pictogram image,
   /// to the selected image from the gallery
   void takePictureWithCamera() {
@@ -56,21 +54,6 @@ class TakePictureWithCameraBloc extends BlocBase {
       _isInputValid.add(true);
     } else {
       _isInputValid.add(false);
-    }
-  }
-
-  /// set accessLevel for the pictogram
-  void setAccessLevel(String access) {
-    _accessString.add(access);
-    switch (access) {
-      case 'Beskyttet':
-        _accessLevel = AccessLevel.PROTECTED;
-        break;
-      case 'Privat':
-        _accessLevel = AccessLevel.PRIVATE;
-        break;
-      default:
-        _accessLevel = AccessLevel.PUBLIC;
     }
   }
 

--- a/lib/blocs/upload_from_gallery_bloc.dart
+++ b/lib/blocs/upload_from_gallery_bloc.dart
@@ -95,7 +95,7 @@ class UploadFromGalleryBloc extends BlocBase {
     _isUploading.add(true);
     return _api.pictogram
         .create(PictogramModel(
-      accessLevel: _accessLevel,
+      accessLevel: AccessLevel.PRIVATE,
       title: _pictogramName,
     ))
         .flatMap((PictogramModel pictogram) {

--- a/lib/blocs/upload_from_gallery_bloc.dart
+++ b/lib/blocs/upload_from_gallery_bloc.dart
@@ -36,8 +36,6 @@ class UploadFromGalleryBloc extends BlocBase {
   final rx_dart.BehaviorSubject<bool> _isUploading =
       rx_dart.BehaviorSubject<bool>.seeded(false);
 
-  AccessLevel _accessLevel = AccessLevel.PUBLIC;
-
   /// pushes an imagePicker screen, then sets the pictogram image,
   /// to the selected image from the gallery
   void chooseImageFromGallery() {
@@ -56,21 +54,6 @@ class UploadFromGalleryBloc extends BlocBase {
       _isInputValid.add(true);
     } else {
       _isInputValid.add(false);
-    }
-  }
-
-  /// set accessLevel for the pictogram
-  void setAccessLevel(String access) {
-    _accessString.add(access);
-    switch (access) {
-      case 'Beskyttet':
-        _accessLevel = AccessLevel.PROTECTED;
-        break;
-      case 'Privat':
-        _accessLevel = AccessLevel.PRIVATE;
-        break;
-      default:
-        _accessLevel = AccessLevel.PUBLIC;
     }
   }
 

--- a/lib/screens/take_picture_with_camera_screen.dart
+++ b/lib/screens/take_picture_with_camera_screen.dart
@@ -75,27 +75,6 @@ class TakePictureWithCamera extends StatelessWidget {
                         borderRadius: BorderRadius.circular(50))),
               ),
             ),
-            Container(
-              padding: const EdgeInsets.only(left: 20),
-              child: StreamBuilder<String>(
-                  stream: _takePictureWithCamera.accessLevel,
-                  builder:
-                      (BuildContext context, AsyncSnapshot<String> snapshot) {
-                    return DropdownButton<String>(
-                      value: snapshot.data,
-                      onChanged: (String newValue) {
-                        _takePictureWithCamera.setAccessLevel(newValue);
-                      },
-                      items: <String>['Institution', 'Privat']
-                          .map<DropdownMenuItem<String>>((String value) {
-                        return DropdownMenuItem<String>(
-                          value: value,
-                          child: Text(value),
-                        );
-                      }).toList(),
-                    );
-                  }),
-            ),
           ],
         ),
         Container(
@@ -199,6 +178,8 @@ class TakePictureWithCamera extends StatelessWidget {
 
   Widget _displayImage(File image) {
     return Container(
+        height: screenHeight / 2,
+        width: screenWidth / 2,
       child: Image.file(image),
       decoration: BoxDecoration(
         borderRadius: _imageBorder,

--- a/lib/screens/upload_image_from_phone_screen.dart
+++ b/lib/screens/upload_image_from_phone_screen.dart
@@ -71,27 +71,6 @@ class UploadImageFromPhone extends StatelessWidget {
                         borderRadius: BorderRadius.circular(50))),
               ),
             ),
-            Container(
-              padding: const EdgeInsets.only(left: 20),
-              child: StreamBuilder<String>(
-                  stream: _uploadFromGallery.accessLevel,
-                  builder:
-                      (BuildContext context, AsyncSnapshot<String> snapshot) {
-                    return DropdownButton<String>(
-                      value: snapshot.data,
-                      onChanged: (String newValue) {
-                        _uploadFromGallery.setAccessLevel(newValue);
-                      },
-                      items: <String>['Institution', 'Privat']
-                          .map<DropdownMenuItem<String>>((String value) {
-                        return DropdownMenuItem<String>(
-                          value: value,
-                          child: Text(value),
-                        );
-                      }).toList(),
-                    );
-                  }),
-            ),
           ],
         ),
         Container(
@@ -194,6 +173,8 @@ class UploadImageFromPhone extends StatelessWidget {
   Widget _displayImage(File image) {
     return Container(
       child: Image.file(image),
+      height: screenHeight / 2,
+      width: screenWidth / 2,
       decoration: BoxDecoration(
         borderRadius: _imageBorder,
       ),


### PR DESCRIPTION
# Description
This code fixes the issues of guardians from other department be able to access pictograms from other departments.

1. Fix Zoom Issues when saving pictogram 
2. Remove Drop-Down menu from save screen
3. Set the only access level to private
4. Remove the unused code left from other access level on Weekplanner


Fixes to subtask for #790 

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)


**Development Configuration**
* Toolchain:
* SDK:

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation, if necessary
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works, if necessary
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [ ] I have Acceptance Tested this on an iOS device. 