### PR TITLE
issue843- added the logout button to weekplan_screen.dart

### DIFF
--- a/lib/screens/weekplan_screen.dart
+++ b/lib/screens/weekplan_screen.dart
@@ -84,7 +84,8 @@ class WeekplanScreen extends StatelessWidget {
                 }
                 : <AppBarIcon, VoidCallback> {
                   // Show icons for citizen role
-                  AppBarIcon.changeToGuardian: () {}
+                  AppBarIcon.changeToGuardian: () {},
+                  AppBarIcon.logout: () {}
                 },
                 isGuardian: weekModeSnapshot.data == WeekplanMode.guardian,
               ),


### PR DESCRIPTION
# Description

Added a logout button for citizen mode

Fixes #\843

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Went into the weekplan for dev-citizen. Changed to citizen mode. Pressed the logout icon.
When pressing the "log ud" button it logs out. When pressing "fortryd" it does not logout.

# Checklist:
Some things have not been checked off, since the only change is like 1 line.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation, if necessary
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works, if necessary
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have Acceptance Tested this on an iOS device. 