### PR TITLE
Feature/696

### DIFF
--- a/lib/blocs/toolbar_bloc.dart
+++ b/lib/blocs/toolbar_bloc.dart
@@ -151,6 +151,11 @@ class ToolbarBloc extends BlocBase {
       tooltip: 'Tilbage',
       onPressed: () {
         Routes.pop(context);
+
+        //WillPopScope(
+          //  onWillPop: () async => false,
+           // child: //you root widget,
+       // );
       },
     );
   }

--- a/lib/blocs/toolbar_bloc.dart
+++ b/lib/blocs/toolbar_bloc.dart
@@ -151,11 +151,6 @@ class ToolbarBloc extends BlocBase {
       tooltip: 'Tilbage',
       onPressed: () {
         Routes.pop(context);
-
-        //WillPopScope(
-          //  onWillPop: () async => false,
-           // child: //you root widget,
-       // );
       },
     );
   }

--- a/lib/screens/show_activity_screen.dart
+++ b/lib/screens/show_activity_screen.dart
@@ -698,11 +698,14 @@ class ShowActivityScreen extends StatelessWidget {
                         onPressed:  () {
                           _activityBloc.completeActivity();
                           Routes.pop(context);
-                          //This removes current context so back button correctly navigates
+                          //This removes current context
+                          // so back button correctly navigates
                           Navigator.pushAndRemoveUntil(
-                            //This creates new context at current screen (refreshes)
+                            //This creates new context at current screen
+                            // (refreshes)
                             context,
-                            MaterialPageRoute<void>(builder: (BuildContext context) =>
+                            MaterialPageRoute<void>(builder:
+                                (BuildContext context) =>
                                 ShowActivityScreen(_activity, _girafUser)),
                                 (Route<dynamic> route) => true,
                           );
@@ -716,7 +719,7 @@ class ShowActivityScreen extends StatelessWidget {
                         width: activitySnapshot.data.state !=
                             ActivityState.Completed
                             ? 100
-                            : 125,
+                            : 130,
                         icon: activitySnapshot.data.state !=
                             ActivityState.Completed
                             ? const ImageIcon(
@@ -734,11 +737,14 @@ class ShowActivityScreen extends StatelessWidget {
                           _activity.state =
                               _activityBloc.getActivity().state;
                           Routes.pop(context);
-                          //This removes current context so back button correctly navigates
+                          //This removes current context
+                          // so back button correctly navigates
                           Navigator.pushAndRemoveUntil(
-                            //This creates new context at current screen (refreshes)
+                            //This creates new context at current screen
+                            // (refreshes)
                             context,
-                            MaterialPageRoute<void>(builder: (BuildContext context) =>
+                            MaterialPageRoute<void>(builder:
+                                (BuildContext context) =>
                                 ShowActivityScreen(_activity, _girafUser)),
                                 (Route<dynamic> route) => true,
                           );

--- a/lib/screens/show_activity_screen.dart
+++ b/lib/screens/show_activity_screen.dart
@@ -714,12 +714,8 @@ class ShowActivityScreen extends StatelessWidget {
                             ActivityState.Canceled,
                         text: activitySnapshot.data.state !=
                             ActivityState.Completed
-                            ? ''
+                            ? 'Afslut'
                             : 'Fortryd',
-                        width: activitySnapshot.data.state !=
-                            ActivityState.Completed
-                            ? 100
-                            : 130,
                         icon: activitySnapshot.data.state !=
                             ActivityState.Completed
                             ? const ImageIcon(

--- a/lib/screens/show_activity_screen.dart
+++ b/lib/screens/show_activity_screen.dart
@@ -695,10 +695,16 @@ class ShowActivityScreen extends StatelessWidget {
 
                     final GirafButton completeButton = GirafButton(
                         key: const Key('CompleteStateToggleButton'),
-                        onPressed: activitySnapshot.data.state !=
-                            ActivityState.Canceled ? () {
+                        onPressed:  () {
                           _activityBloc.completeActivity();
-                        }: null,
+                          Routes.pop(context);
+                          Navigator.pushAndRemoveUntil(
+                            context,
+                            MaterialPageRoute<void>(builder: (context) =>
+                                ShowActivityScreen(_activity, _girafUser)),
+                                (Route<dynamic> route) => true,
+                          );
+                        },
                         isEnabled: activitySnapshot.data.state !=
                             ActivityState.Canceled,
                         text: activitySnapshot.data.state !=
@@ -725,6 +731,13 @@ class ShowActivityScreen extends StatelessWidget {
                           _activityBloc.cancelActivity();
                           _activity.state =
                               _activityBloc.getActivity().state;
+                          Routes.pop(context);
+                          Navigator.pushAndRemoveUntil(
+                            context,
+                            MaterialPageRoute<void>(builder: (context) =>
+                                ShowActivityScreen(_activity, _girafUser)),
+                                (Route<dynamic> route) => true,
+                          );
                         },
                         isEnabled: activitySnapshot.data.state !=
                             ActivityState.Completed,

--- a/lib/screens/show_activity_screen.dart
+++ b/lib/screens/show_activity_screen.dart
@@ -697,8 +697,8 @@ class ShowActivityScreen extends StatelessWidget {
                         key: const Key('CompleteStateToggleButton'),
                         onPressed:  () {
                           _activityBloc.completeActivity();
-                          Routes.pop(context);
-                          Navigator.pushAndRemoveUntil(
+                          Routes.pop(context); //This removes current context so back button correctly navigates
+                          Navigator.pushAndRemoveUntil( //This creates new context at current screen (refreshes)
                             context,
                             MaterialPageRoute<void>(builder: (context) =>
                                 ShowActivityScreen(_activity, _girafUser)),
@@ -731,8 +731,8 @@ class ShowActivityScreen extends StatelessWidget {
                           _activityBloc.cancelActivity();
                           _activity.state =
                               _activityBloc.getActivity().state;
-                          Routes.pop(context);
-                          Navigator.pushAndRemoveUntil(
+                          Routes.pop(context); //This removes current context so back button correctly navigates
+                          Navigator.pushAndRemoveUntil( //This creates new context at current screen (refreshes)
                             context,
                             MaterialPageRoute<void>(builder: (context) =>
                                 ShowActivityScreen(_activity, _girafUser)),

--- a/lib/screens/show_activity_screen.dart
+++ b/lib/screens/show_activity_screen.dart
@@ -697,10 +697,12 @@ class ShowActivityScreen extends StatelessWidget {
                         key: const Key('CompleteStateToggleButton'),
                         onPressed:  () {
                           _activityBloc.completeActivity();
-                          Routes.pop(context); //This removes current context so back button correctly navigates
-                          Navigator.pushAndRemoveUntil( //This creates new context at current screen (refreshes)
+                          Routes.pop(context);
+                          //This removes current context so back button correctly navigates
+                          Navigator.pushAndRemoveUntil(
+                            //This creates new context at current screen (refreshes)
                             context,
-                            MaterialPageRoute<void>(builder: (context) =>
+                            MaterialPageRoute<void>(builder: (BuildContext context) =>
                                 ShowActivityScreen(_activity, _girafUser)),
                                 (Route<dynamic> route) => true,
                           );
@@ -731,10 +733,12 @@ class ShowActivityScreen extends StatelessWidget {
                           _activityBloc.cancelActivity();
                           _activity.state =
                               _activityBloc.getActivity().state;
-                          Routes.pop(context); //This removes current context so back button correctly navigates
-                          Navigator.pushAndRemoveUntil( //This creates new context at current screen (refreshes)
+                          Routes.pop(context);
+                          //This removes current context so back button correctly navigates
+                          Navigator.pushAndRemoveUntil(
+                            //This creates new context at current screen (refreshes)
                             context,
-                            MaterialPageRoute<void>(builder: (context) =>
+                            MaterialPageRoute<void>(builder: (BuildContext context) =>
                                 ShowActivityScreen(_activity, _girafUser)),
                                 (Route<dynamic> route) => true,
                           );

--- a/lib/screens/show_activity_screen.dart
+++ b/lib/screens/show_activity_screen.dart
@@ -695,12 +695,20 @@ class ShowActivityScreen extends StatelessWidget {
 
                     final GirafButton completeButton = GirafButton(
                         key: const Key('CompleteStateToggleButton'),
-                        onPressed: () {
+                        onPressed: activitySnapshot.data.state !=
+                            ActivityState.Canceled ? () {
                           _activityBloc.completeActivity();
-                        },
+                        }: null,
                         isEnabled: activitySnapshot.data.state !=
                             ActivityState.Canceled,
-                        width: 100,
+                        text: activitySnapshot.data.state !=
+                            ActivityState.Completed
+                            ? ''
+                            : 'Fortryd',
+                        width: activitySnapshot.data.state !=
+                            ActivityState.Completed
+                            ? 100
+                            : 125,
                         icon: activitySnapshot.data.state !=
                             ActivityState.Completed
                             ? const ImageIcon(


### PR DESCRIPTION
# Description

Fixes #\696 by reloading the screen after pressing a button. This is not optimal since it flashes but after trying everything we could think of to make a better solution and nothing working this is a working fix.

## Type of change

*Please delete options that are not relevant.*

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

No unit tests has been set up since every value is the same as before except the screen is updated correctly.

It has been checked that both accept and cancel correctly disables the other button and every other functionality on the screen still works.

**Development Configuration**
Set up after guide

# Checklist:

- [ X] My code follows the style guidelines of this project
- [ X] I have performed a self-review of my own code
- [ X] I have commented my code, particularly in hard-to-understand areas
- [X ] I have made corresponding changes to the documentation, if necessary
- [ X] My changes generate no new warnings
- [ X] I have added tests that prove my fix is effective or that my feature works, if necessary
- [ X] New and existing unit tests pass locally with my changes
- [ X] Any dependent changes have been merged and published in downstream modules
- [ ] I have Acceptance Tested this on an iOS device. 