### PR TITLE
Previous weeks now close by default

### DIFF
--- a/lib/screens/weekplan_selector_screen.dart
+++ b/lib/screens/weekplan_selector_screen.dart
@@ -41,7 +41,7 @@ class WeekplanSelectorScreen extends StatefulWidget {
 }
 
  class _WeekplanSelectorScreenState extends State<WeekplanSelectorScreen> {
-  bool showOldWeeks = true;
+  bool showOldWeeks = false;
 
  void _toggleOldWeeks() {
    setState(() {


### PR DESCRIPTION
Changed variable value in weekplan_selector_screen

# Description
Changed the bool value for the past-week-dropdown-box from true (open by default) to false (closed by default).


Fixes #836 

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Only acceptance tests were conducted on an emulated Android tablet (Pixel C API 30). Recreate: Login to guardian-dev, click on dev-citizen, see that "Overståede uger" dropdown box is closed. 


**Development Configuration**

* Flutter version: 2.0.5
* Dart version: 2.12.3

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas, if necessary
- [x] I have made corresponding changes to the documentation, if necessary
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have Acceptance Tested this on an iOS device
- [x] I have Acceptance Tested this on an Android device
