### PR TITLE
Previous weeks now closed by default

### DIFF
--- a/lib/screens/weekplan_selector_screen.dart
+++ b/lib/screens/weekplan_selector_screen.dart
@@ -41,7 +41,7 @@ class WeekplanSelectorScreen extends StatefulWidget {
 }
 
 class _WeekplanSelectorScreenState extends State<WeekplanSelectorScreen> {
-  bool showOldWeeks = true;
+  bool showOldWeeks = false;
 
   void _toggleOldWeeks() {
     setState(

--- a/lib/screens/weekplan_selector_screen.dart
+++ b/lib/screens/weekplan_selector_screen.dart
@@ -141,14 +141,15 @@ class _WeekplanSelectorScreenState extends State<WeekplanSelectorScreen> {
           _toggleOldWeeks();
         },
       ),
-      showOldWeeks
-          ? Expanded(
+
+        Visibility(
+          visible: showOldWeeks,
+            child: Expanded(
               flex: 5,
               child: Container( // Container with old weeks if shown
                 // Background color of the old weeks
                 color: Colors.grey.shade600,
-                child: _buildWeekplanGridview(context, oldWeekModels, false)))
-          : Container(), // Empty container if old weeks are hidden
+                child: _buildWeekplanGridview(context, oldWeekModels, false))))
     ]));
   }
 

--- a/test/screens/copy_resolve_screen_test.dart
+++ b/test/screens/copy_resolve_screen_test.dart
@@ -154,6 +154,7 @@ void main() {
           weekModel: weekplan1,
           forThisCitizen: true)));
 
+
       expect(find.text(weekplan1.weekNumber.toString()), findsOneWidget);
       expect(find.text(weekplan1.weekYear.toString()), findsOneWidget);
       expect(find.text(weekplan1.name), findsOneWidget);
@@ -163,13 +164,22 @@ void main() {
       await tester.pumpAndSettle();
       expect(find.text('3'), findsOneWidget);
 
+      await tester.enterText(
+          find.byKey(const Key('WeekYearTextFieldKey')), '2020');
+      await tester.pumpAndSettle();
+      expect(find.text('2020'), findsOneWidget);
+
       expect(find.byKey(const Key('CopyResolveSaveButton')), findsOneWidget);
       await tester.tap(find.byKey(const Key('CopyResolveSaveButton')));
       await tester.pumpAndSettle();
 
       expect(find.byType(WeekplanSelectorScreen), findsOneWidget);
 
-      expect(find.text('Uge: 3      År: 2020'), findsOneWidget);
+      // Expands the old week section
+      expect(find.byKey(const Key('ShowOldWeeks')), findsOneWidget);
+      await tester.tap(find.byKey(const Key('ShowOldWeeks')));
+      await tester.pumpAndSettle();
+
       expect(find.text('weekplan1'), findsNWidgets(2));
     });
 

--- a/test/screens/weekplan_selector_screen_test.dart
+++ b/test/screens/weekplan_selector_screen_test.dart
@@ -261,12 +261,12 @@ void main() {
     expect(find.text('Overståede uger'), findsOneWidget);
   });
 
-  testWidgets('Should have two GridView Widgets', (WidgetTester tester) async {
+  testWidgets('Should have one GridView Widget', (WidgetTester tester) async {
     await tester
         .pumpWidget(MaterialApp(home: WeekplanSelectorScreen(mockUser)));
 
     expect(find.byWidgetPredicate((Widget widget) => widget is GridView),
-        findsNWidgets(2));
+        findsNWidgets(1));
   });
 
   testWidgets('Weekmodels exist with the expected names',
@@ -274,6 +274,11 @@ void main() {
     await tester
         .pumpWidget(MaterialApp(home: WeekplanSelectorScreen(mockUser)));
     await tester.pump(Duration.zero);
+
+    // Expands the old week section
+    expect(find.byKey(const Key('ShowOldWeeks')), findsOneWidget);
+    await tester.tap(find.byKey(const Key('ShowOldWeeks')));
+    await tester.pumpAndSettle();
 
     expect(find.text('Tilføj ugeplan'), findsOneWidget);
     expect(find.text(nameWeekModel1), findsOneWidget);
@@ -285,7 +290,11 @@ void main() {
         .pumpWidget(MaterialApp(home: WeekplanSelectorScreen(mockUser)));
     await tester.pump(Duration.zero);
 
-    expect(find.text('Uge: 1      År: 2020'), findsNWidgets(2));
+    // Expands the old week section
+    expect(find.byKey(const Key('ShowOldWeeks')), findsOneWidget);
+    await tester.tap(find.byKey(const Key('ShowOldWeeks')));
+    await tester.pumpAndSettle();
+
     expect(find.byKey(const Key('weekYear')), findsNWidgets(2));
   });
 
@@ -347,6 +356,11 @@ void main() {
         .pumpWidget(MaterialApp(home: WeekplanSelectorScreen(mockUser)));
     await tester.pumpAndSettle();
 
+    // Expands the old week section
+    expect(find.byKey(const Key('ShowOldWeeks')), findsOneWidget);
+    await tester.tap(find.byKey(const Key('ShowOldWeeks')));
+    await tester.pumpAndSettle();
+
     expect(find.byKey(Key(weekModel1.name)), findsOneWidget);
 
     await tester.tap(find.byTooltip('Rediger'));
@@ -368,6 +382,11 @@ void main() {
       (WidgetTester tester) async {
     await tester
         .pumpWidget(MaterialApp(home: WeekplanSelectorScreen(mockUser)));
+    await tester.pumpAndSettle();
+
+    // Expands the old week section
+    expect(find.byKey(const Key('ShowOldWeeks')), findsOneWidget);
+    await tester.tap(find.byKey(const Key('ShowOldWeeks')));
     await tester.pumpAndSettle();
 
     expect(find.byKey(Key(weekModel1.name)), findsOneWidget);
@@ -396,6 +415,11 @@ void main() {
         .pumpWidget(MaterialApp(home: WeekplanSelectorScreen(mockUser)));
     await tester.pumpAndSettle();
 
+    // Expands the old week section
+    expect(find.byKey(const Key('ShowOldWeeks')), findsOneWidget);
+    await tester.tap(find.byKey(const Key('ShowOldWeeks')));
+    await tester.pumpAndSettle();
+
     await tester.tap(find.byTooltip('Rediger'));
     await tester.pumpAndSettle();
 
@@ -412,6 +436,11 @@ void main() {
       (WidgetTester tester) async {
     await tester
         .pumpWidget(MaterialApp(home: WeekplanSelectorScreen(mockUser)));
+    await tester.pumpAndSettle();
+
+    // Expands the old week section
+    expect(find.byKey(const Key('ShowOldWeeks')), findsOneWidget);
+    await tester.tap(find.byKey(const Key('ShowOldWeeks')));
     await tester.pumpAndSettle();
 
     expect(find.text(nameWeekModel1), findsOneWidget);
@@ -434,10 +463,15 @@ void main() {
     expect(find.byKey(const Key('ConfirmDialogCancelButton')), findsOneWidget);
   });
 
-  testWidgets('Marking an weekmodel and deleting removes it',
+  testWidgets('Marking a weekmodel and deleting removes it',
       (WidgetTester tester) async {
     await tester
         .pumpWidget(MaterialApp(home: WeekplanSelectorScreen(mockUser)));
+    await tester.pumpAndSettle();
+
+    // Expands the old week section
+    expect(find.byKey(const Key('ShowOldWeeks')), findsOneWidget);
+    await tester.tap(find.byKey(const Key('ShowOldWeeks')));
     await tester.pumpAndSettle();
 
     expect(find.text(nameWeekModel1), findsOneWidget);
@@ -461,6 +495,11 @@ void main() {
       (WidgetTester tester) async {
     await tester
         .pumpWidget(MaterialApp(home: WeekplanSelectorScreen(mockUser)));
+    await tester.pumpAndSettle();
+
+    // Expands the old week section
+    expect(find.byKey(const Key('ShowOldWeeks')), findsOneWidget);
+    await tester.tap(find.byKey(const Key('ShowOldWeeks')));
     await tester.pumpAndSettle();
 
     expect(find.byKey(Key(weekModel1.name)), findsOneWidget);
@@ -493,6 +532,11 @@ void main() {
         .pumpWidget(MaterialApp(home: WeekplanSelectorScreen(mockUser)));
     await tester.pumpAndSettle();
 
+    // Expands the old week section
+    expect(find.byKey(const Key('ShowOldWeeks')), findsOneWidget);
+    await tester.tap(find.byKey(const Key('ShowOldWeeks')));
+    await tester.pumpAndSettle();
+
     expect(find.byKey(Key(weekModel1.name)), findsOneWidget);
 
     await tester.tap(find.byTooltip('Rediger'));
@@ -519,6 +563,11 @@ void main() {
         .pumpWidget(MaterialApp(home: WeekplanSelectorScreen(mockUser)));
     await tester.pumpAndSettle();
 
+    // Expands the old week section
+    expect(find.byKey(const Key('ShowOldWeeks')), findsOneWidget);
+    await tester.tap(find.byKey(const Key('ShowOldWeeks')));
+    await tester.pumpAndSettle();
+
     await tester.tap(find.byTooltip('Rediger'));
     await tester.pumpAndSettle();
 
@@ -535,6 +584,11 @@ void main() {
           (WidgetTester tester) async {
         await tester
             .pumpWidget(MaterialApp(home: WeekplanSelectorScreen(mockUser)));
+        await tester.pumpAndSettle();
+
+        // Expands the old week section
+        expect(find.byKey(const Key('ShowOldWeeks')), findsOneWidget);
+        await tester.tap(find.byKey(const Key('ShowOldWeeks')));
         await tester.pumpAndSettle();
 
         await tester.tap(find.byTooltip('Rediger'));
@@ -572,6 +626,11 @@ void main() {
         .pumpWidget(MaterialApp(home: WeekplanSelectorScreen(mockUser)));
     await tester.pumpAndSettle();
 
+    // Expands the old week section
+    expect(find.byKey(const Key('ShowOldWeeks')), findsOneWidget);
+    await tester.tap(find.byKey(const Key('ShowOldWeeks')));
+    await tester.pumpAndSettle();
+
     await tester.tap(find.byTooltip('Rediger'));
     await tester.pumpAndSettle();
 
@@ -592,6 +651,11 @@ void main() {
       (WidgetTester tester) async {
     await tester
         .pumpWidget(MaterialApp(home: WeekplanSelectorScreen(mockUser)));
+    await tester.pumpAndSettle();
+
+    // Expands the old week section
+    expect(find.byKey(const Key('ShowOldWeeks')), findsOneWidget);
+    await tester.tap(find.byKey(const Key('ShowOldWeeks')));
     await tester.pumpAndSettle();
 
     await tester.tap(find.byTooltip('Rediger'));
@@ -621,6 +685,11 @@ void main() {
         .pumpWidget(MaterialApp(home: WeekplanSelectorScreen(mockUser)));
     await tester.pumpAndSettle();
 
+    // Expands the old week section
+    expect(find.byKey(const Key('ShowOldWeeks')), findsOneWidget);
+    await tester.tap(find.byKey(const Key('ShowOldWeeks')));
+    await tester.pumpAndSettle();
+
     await tester.tap(find.byTooltip('Rediger'));
     await tester.pumpAndSettle();
 
@@ -638,6 +707,11 @@ void main() {
       'and the CopyResolverScreen comes up', (WidgetTester tester) async {
     await tester
         .pumpWidget(MaterialApp(home: WeekplanSelectorScreen(mockUser)));
+    await tester.pumpAndSettle();
+
+    // Expands the old week section
+    expect(find.byKey(const Key('ShowOldWeeks')), findsOneWidget);
+    await tester.tap(find.byKey(const Key('ShowOldWeeks')));
     await tester.pumpAndSettle();
 
     await tester.tap(find.byTooltip('Rediger'));
@@ -671,6 +745,11 @@ void main() {
         .pumpWidget(MaterialApp(home: WeekplanSelectorScreen(mockUser)));
     await tester.pumpAndSettle();
 
+    // Expands the old week section
+    expect(find.byKey(const Key('ShowOldWeeks')), findsOneWidget);
+    await tester.tap(find.byKey(const Key('ShowOldWeeks')));
+    await tester.pumpAndSettle();
+
     expect(find.byKey(Key(weekModel1.name)), findsOneWidget);
     expect(find.byKey(Key(mockWeekModel.name)), findsNothing);
     expect(find.byKey(Key(weekModel2.name)), findsOneWidget);
@@ -696,15 +775,15 @@ void main() {
     await tester
         .pumpWidget(MaterialApp(home: WeekplanSelectorScreen(mockUser)));
     await tester.pump();
-    expect(find.byKey(const Key('HideOldWeeks')), findsOneWidget);
-    await tester.tap(find.byKey(const Key('HideOldWeeks')));
-    await tester.pumpAndSettle();
     expect(find.byKey(const Key('ShowOldWeeks')), findsOneWidget);
-    expect(find.byKey(const Key('HideOldWeeks')), findsNothing);
-    await tester.pumpAndSettle();
     await tester.tap(find.byKey(const Key('ShowOldWeeks')));
     await tester.pumpAndSettle();
     expect(find.byKey(const Key('HideOldWeeks')), findsOneWidget);
     expect(find.byKey(const Key('ShowOldWeeks')), findsNothing);
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('HideOldWeeks')));
+    await tester.pumpAndSettle();
+    expect(find.byKey(const Key('ShowOldWeeks')), findsOneWidget);
+    expect(find.byKey(const Key('HideOldWeeks')), findsNothing);
   });
 }


### PR DESCRIPTION
Changed variable value in weekplan_selector_screen

# Description
Changed the bool value for the past-week-dropdown-box from true (open by default) to false (closed by default).


Fixes #836 

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Only acceptance tests were conducted on an emulated Android tablet (Pixel C API 30). Recreate: Login to guardian-dev, click on dev-citizen, see that "Overståede uger" dropdown box is closed. 


Development Configuration

* Flutter version: 2.0.5
* Dart version: 2.12.3

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas, if necessary
- [x] I have made corresponding changes to the documentation, if necessary
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have Acceptance Tested this on an iOS device
- [x] I have Acceptance Tested this on an Android device