### PR TITLE
As a Guardian create a new Trustee or Guardian - Feature/625

### DIFF
--- a/lib/blocs/new_citizen_bloc.dart
+++ b/lib/blocs/new_citizen_bloc.dart
@@ -85,6 +85,17 @@ class NewCitizenBloc extends BlocBase {
     );
   }
 
+  /// Method called with information about the guardian attached to the citizen.
+  Stream<GirafUserModel> createGuardian() {
+    return _api.account.register(
+        usernameController.value,
+        passwordController.value,
+        displayNameController.value,
+        departmentId: _user.department,
+        role: Role.Guardian
+    );
+  }
+
   /// Gives information about whether all inputs are valid.
   Stream<bool> get allInputsAreValidStream =>
       rx_dart.Rx.combineLatest4<bool, bool, bool, bool, bool>(

--- a/lib/screens/choose_citizen_screen.dart
+++ b/lib/screens/choose_citizen_screen.dart
@@ -127,7 +127,7 @@ class _ChooseCitizenScreenState extends State<ChooseCitizenScreen> {
               ),
                 child: const Center(
                   child: AutoSizeText(
-                    'Tilføj Borger',
+                    'Tilføj Bruger',
                     style: TextStyle(fontSize: GirafFont.large),
                   ),
                 )

--- a/lib/screens/new_citizen_screen.dart
+++ b/lib/screens/new_citizen_screen.dart
@@ -7,6 +7,8 @@ import 'package:weekplanner/routes.dart';
 import 'package:weekplanner/widgets/giraf_app_bar_widget.dart';
 import 'package:weekplanner/widgets/giraf_button_widget.dart';
 
+enum Roles {guardian, trustee, citizen}
+
 /// Screen for creating a new citizen
 class NewCitizenScreen extends StatefulWidget {
   /// Constructor for the NewCitizenScreen()
@@ -22,6 +24,7 @@ class NewCitizenScreen extends StatefulWidget {
 
 class _NewCitizenScreenState extends State<NewCitizenScreen> {
   final ApiErrorTranslater _translator = ApiErrorTranslater();
+  Roles _role = Roles.citizen;
 
   @override
   Widget build(BuildContext context) {
@@ -49,6 +52,64 @@ class _NewCitizenScreenState extends State<NewCitizenScreen> {
                           : 'Navn skal udfyldes',
                     ),
                     onChanged: widget._bloc.onDisplayNameChange.add,
+                  );
+                }),
+          ),
+          Padding(
+            padding:
+                const EdgeInsets.only(left: 16, top: 6, right: 16, bottom: 2.5),
+            child: StreamBuilder<bool>(
+                stream: widget._bloc.validDisplayNameStream,
+                builder: (BuildContext context, AsyncSnapshot<bool> snapshot) {
+                  return Column(
+                    children: <Widget>[
+                      Row(
+                        children: <Widget> [
+                          Expanded(
+                            child: ListTile(
+                              title: const Text('Guardian'),
+                              leading: Radio<Roles> (
+                                value: Roles.guardian,
+                                groupValue: _role,
+                                onChanged: (Roles value) {
+                                  setState(() {
+                                    _role = value;
+                                  });
+                                },
+                              ),
+                            ),
+                          ),
+                          Expanded(
+                            child: ListTile(
+                              title: const Text('Trustee'),
+                              leading: Radio<Roles> (
+                                value: Roles.trustee,
+                                groupValue: _role,
+                                onChanged: (Roles value) {
+                                  setState(() {
+                                    _role = value;
+                                  });
+                                },
+                              ),
+                            ),
+                          ),
+                          Expanded(
+                            child: ListTile(
+                              title: const Text('Citizen'),
+                              leading: Radio<Roles> (
+                                value: Roles.citizen,
+                                groupValue: _role,
+                                onChanged: (Roles value) {
+                                  setState(() {
+                                    _role = value;
+                                  });
+                                },
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ],
                   );
                 }),
           ),
@@ -129,13 +190,38 @@ class _NewCitizenScreenState extends State<NewCitizenScreen> {
                   isEnabled: false,
                   isEnabledStream: widget._bloc.allInputsAreValidStream,
                   onPressed: () {
-                    widget._bloc.createCitizen().listen((GirafUserModel response) {
-                      if (response != null) {
-                        Routes.pop<GirafUserModel>(context, response);
-                        widget._bloc.resetBloc();
-                      }
-                    }).onError((Object error) =>
-                        _translator.catchApiError(error, context));
+                    switch(_role) {
+                      case Roles.guardian:
+                        widget._bloc.createGuardian()
+                            .listen((GirafUserModel response) {
+                          if (response != null) {
+                            Routes.pop<GirafUserModel>(context, response);
+                            widget._bloc.resetBloc();
+                          }})
+                            .onError((Object error) =>
+                            _translator.catchApiError(error, context));
+                        break;
+                      case Roles.trustee:
+                        widget._bloc.createTrustee()
+                            .listen((GirafUserModel response) {
+                          if (response != null) {
+                            Routes.pop<GirafUserModel>(context, response);
+                            widget._bloc.resetBloc();
+                          }})
+                            .onError((Object error) =>
+                            _translator.catchApiError(error, context));
+                        break;
+                      case Roles.citizen:
+                        widget._bloc.createCitizen()
+                            .listen((GirafUserModel response) {
+                          if (response != null) {
+                            Routes.pop<GirafUserModel>(context, response);
+                            widget._bloc.resetBloc();
+                          }})
+                            .onError((Object error) =>
+                            _translator.catchApiError(error, context));
+                        break;
+                    }
                   },
                 ),
               ),

--- a/lib/screens/new_citizen_screen.dart
+++ b/lib/screens/new_citizen_screen.dart
@@ -26,6 +26,11 @@ class _NewCitizenScreenState extends State<NewCitizenScreen> {
   final ApiErrorTranslater _translator = ApiErrorTranslater();
   Roles _role = Roles.citizen;
 
+  void previousRoute(GirafUserModel response) {
+    Routes.pop<GirafUserModel>(context, response);
+    widget._bloc.resetBloc();
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -195,8 +200,7 @@ class _NewCitizenScreenState extends State<NewCitizenScreen> {
                         widget._bloc.createGuardian()
                             .listen((GirafUserModel response) {
                           if (response != null) {
-                            Routes.pop<GirafUserModel>(context, response);
-                            widget._bloc.resetBloc();
+                            previousRoute(response);
                           }})
                             .onError((Object error) =>
                             _translator.catchApiError(error, context));
@@ -205,8 +209,7 @@ class _NewCitizenScreenState extends State<NewCitizenScreen> {
                         widget._bloc.createTrustee()
                             .listen((GirafUserModel response) {
                           if (response != null) {
-                            Routes.pop<GirafUserModel>(context, response);
-                            widget._bloc.resetBloc();
+                            previousRoute(response);
                           }})
                             .onError((Object error) =>
                             _translator.catchApiError(error, context));
@@ -215,8 +218,7 @@ class _NewCitizenScreenState extends State<NewCitizenScreen> {
                         widget._bloc.createCitizen()
                             .listen((GirafUserModel response) {
                           if (response != null) {
-                            Routes.pop<GirafUserModel>(context, response);
-                            widget._bloc.resetBloc();
+                            previousRoute(response);
                           }})
                             .onError((Object error) =>
                             _translator.catchApiError(error, context));

--- a/lib/screens/new_citizen_screen.dart
+++ b/lib/screens/new_citizen_screen.dart
@@ -35,7 +35,7 @@ class _NewCitizenScreenState extends State<NewCitizenScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: GirafAppBar(
-        title: 'Ny borger',
+        title: 'Ny bruger',
       ),
       body: ListView(
         children: <Widget>[
@@ -191,7 +191,7 @@ class _NewCitizenScreenState extends State<NewCitizenScreen> {
                 child: GirafButton(
                   key: const Key('saveButton'),
                   icon: const ImageIcon(AssetImage('assets/icons/save.png')),
-                  text: 'Gem borger',
+                  text: 'Gem bruger',
                   isEnabled: false,
                   isEnabledStream: widget._bloc.allInputsAreValidStream,
                   onPressed: () {

--- a/lib/screens/new_citizen_screen.dart
+++ b/lib/screens/new_citizen_screen.dart
@@ -8,14 +8,20 @@ import 'package:weekplanner/widgets/giraf_app_bar_widget.dart';
 import 'package:weekplanner/widgets/giraf_button_widget.dart';
 
 /// Screen for creating a new citizen
-class NewCitizenScreen extends StatelessWidget {
+class NewCitizenScreen extends StatefulWidget {
   /// Constructor for the NewCitizenScreen()
   NewCitizenScreen() : _bloc = di.getDependency<NewCitizenBloc>() {
     _bloc.initialize();
   }
 
-  final ApiErrorTranslater _translator = ApiErrorTranslater();
   final NewCitizenBloc _bloc;
+
+  @override
+  _NewCitizenScreenState createState() => _NewCitizenScreenState();
+}
+
+class _NewCitizenScreenState extends State<NewCitizenScreen> {
+  final ApiErrorTranslater _translator = ApiErrorTranslater();
 
   @override
   Widget build(BuildContext context) {
@@ -29,7 +35,7 @@ class NewCitizenScreen extends StatelessWidget {
             padding:
                 const EdgeInsets.only(left: 16, top: 6, right: 16, bottom: 2.5),
             child: StreamBuilder<bool>(
-                stream: _bloc.validDisplayNameStream,
+                stream: widget._bloc.validDisplayNameStream,
                 builder: (BuildContext context, AsyncSnapshot<bool> snapshot) {
                   return TextFormField(
                     key: const Key('displayNameField'),
@@ -38,18 +44,18 @@ class NewCitizenScreen extends StatelessWidget {
                           const OutlineInputBorder(borderSide: BorderSide()),
                       labelText: 'Navn',
                       errorText: (snapshot?.data == true) &&
-                              _bloc.displayNameController.value != null
+                              widget._bloc.displayNameController.value != null
                           ? null
                           : 'Navn skal udfyldes',
                     ),
-                    onChanged: _bloc.onDisplayNameChange.add,
+                    onChanged: widget._bloc.onDisplayNameChange.add,
                   );
                 }),
           ),
           Padding(
             padding: const EdgeInsets.symmetric(vertical: 3, horizontal: 16),
             child: StreamBuilder<bool>(
-                stream: _bloc.validUsernameStream,
+                stream: widget._bloc.validUsernameStream,
                 builder: (BuildContext context, AsyncSnapshot<bool> snapshot) {
                   return TextFormField(
                     key: const Key('usernameField'),
@@ -58,20 +64,20 @@ class NewCitizenScreen extends StatelessWidget {
                           const OutlineInputBorder(borderSide: BorderSide()),
                       labelText: 'Brugernavn',
                       errorText: (snapshot?.data == true) &&
-                              _bloc.usernameController.value != null
+                              widget._bloc.usernameController.value != null
                           ? null
                           // cant make it shorter because of the string
                           // ignore: lines_longer_than_80_chars
                           : 'Brugernavn er tomt eller indeholder et ugyldigt tegn',
                     ),
-                    onChanged: _bloc.onUsernameChange.add,
+                    onChanged: widget._bloc.onUsernameChange.add,
                   );
                 }),
           ),
           Padding(
             padding: const EdgeInsets.symmetric(vertical: 3, horizontal: 16),
             child: StreamBuilder<bool>(
-                stream: _bloc.validPasswordStream,
+                stream: widget._bloc.validPasswordStream,
                 builder: (BuildContext context, AsyncSnapshot<bool> snapshot) {
                   return TextFormField(
                     key: const Key('passwordField'),
@@ -80,13 +86,13 @@ class NewCitizenScreen extends StatelessWidget {
                           const OutlineInputBorder(borderSide: BorderSide()),
                       labelText: 'Kodeord',
                       errorText: (snapshot?.data == true) &&
-                              _bloc.passwordController.value != null
+                              widget._bloc.passwordController.value != null
                           ? null
                           // cant make it shorter because of the string
                           // ignore: lines_longer_than_80_chars
                           : 'Kodeord må ikke indeholde mellemrum eller være tom',
                     ),
-                    onChanged: _bloc.onPasswordChange.add,
+                    onChanged: widget._bloc.onPasswordChange.add,
                     obscureText: true,
                   );
                 }),
@@ -94,7 +100,7 @@ class NewCitizenScreen extends StatelessWidget {
           Padding(
             padding: const EdgeInsets.symmetric(vertical: 3, horizontal: 16),
             child: StreamBuilder<bool>(
-                stream: _bloc.validPasswordVerificationStream,
+                stream: widget._bloc.validPasswordVerificationStream,
                 builder: (BuildContext context, AsyncSnapshot<bool> snapshot) {
                   return TextFormField(
                     key: const Key('passwordVerifyField'),
@@ -106,7 +112,7 @@ class NewCitizenScreen extends StatelessWidget {
                           ? null
                           : 'Kodeord skal være ens',
                     ),
-                    onChanged: _bloc.onPasswordVerifyChange.add,
+                    onChanged: widget._bloc.onPasswordVerifyChange.add,
                     obscureText: true,
                   );
                 }),
@@ -121,12 +127,12 @@ class NewCitizenScreen extends StatelessWidget {
                   icon: const ImageIcon(AssetImage('assets/icons/save.png')),
                   text: 'Gem borger',
                   isEnabled: false,
-                  isEnabledStream: _bloc.allInputsAreValidStream,
+                  isEnabledStream: widget._bloc.allInputsAreValidStream,
                   onPressed: () {
-                    _bloc.createCitizen().listen((GirafUserModel response) {
+                    widget._bloc.createCitizen().listen((GirafUserModel response) {
                       if (response != null) {
                         Routes.pop<GirafUserModel>(context, response);
-                        _bloc.resetBloc();
+                        widget._bloc.resetBloc();
                       }
                     }).onError((Object error) =>
                         _translator.catchApiError(error, context));

--- a/test/blocs/new_citizen_bloc_test.dart
+++ b/test/blocs/new_citizen_bloc_test.dart
@@ -62,6 +62,28 @@ void main() {
     done();
   }));
 
+  test('Should save a new guardian', async((DoneFn done) {
+    bloc.onUsernameChange.add(user.username);
+    bloc.onPasswordChange.add('1234');
+    bloc.onPasswordVerifyChange.add('1234');
+    bloc.onDisplayNameChange.add(user.displayName);
+    bloc.createGuardian();
+
+    verify(bloc.createGuardian());
+    done();
+  }));
+
+  test('Should save a new trustee', async((DoneFn done) {
+    bloc.onUsernameChange.add(user.username);
+    bloc.onPasswordChange.add('1234');
+    bloc.onPasswordVerifyChange.add('1234');
+    bloc.onDisplayNameChange.add(user.displayName);
+    bloc.createTrustee();
+
+    verify(bloc.createTrustee());
+    done();
+  }));
+
   test('All inputs are valid', async((DoneFn done) {
     bloc.onUsernameChange.add(user.username);
     bloc.onPasswordChange.add('1234');

--- a/test/screens/new_citizen_screen_test.dart
+++ b/test/screens/new_citizen_screen_test.dart
@@ -186,6 +186,12 @@ void main() {
     expect(find.text('birgit'), findsNWidgets(1));
   });
 
+  testWidgets('Role radio buttons are rendered', (WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(home: NewCitizenScreen()));
+
+    expect(find.byType(ListTile), findsNWidgets(3));
+  });
+
   testWidgets('You can input a password', (WidgetTester tester) async {
     await tester.pumpWidget(MaterialApp(home: NewCitizenScreen()));
     await tester.enterText(find.byKey(const Key('passwordField')), 'password');


### PR DESCRIPTION
# Description

Converted <code>new_citizen_screen.dart</code> from <code>StatelessWidget</code> to <code>StateFulWidget</code>, in order to change state of role variable at the click of radio buttons. The horizontal radio buttons are made to give users the choice of role when registering.

Fixes #625 

## IMPORTANT dependency
**The pull request is related to pull request: https://github.com/aau-giraf/web-api/pull/271  - Please merge both**

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Test have been added to ensure that rendering of radio buttons happens when registering.
Tests when registration of a new guardian and trustee have been added.

**Development Configuration**

* Flutter version: 2.0.5
* Dart version: 2.12.3

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas, if necessary
- [ ] I have made corresponding changes to the documentation, if necessary
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works, if necessary
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [ ] I have Acceptance Tested this on an iOS device
- [X] I have Acceptance Tested this on an Android device
