### PR TITLE
Feature/673

### DIFF
--- a/lib/screens/settings_screens/settings_screen.dart
+++ b/lib/screens/settings_screens/settings_screen.dart
@@ -154,6 +154,15 @@ class SettingsScreen extends StatelessWidget {
                   _settingsBloc.loadSettings(_user);
                 });
               }),
+              SettingsCheckMarkButton.fromBoolean(
+                //Ingen backend implementeret, KUN VISUELT
+                  settingsModel.pictogramText, 'Vis bekræftelse popups', () {
+                    //pictogramText skal erstattes med showPopup, som også skal laves i backend
+                _settingsBloc.updateSettings(_user.id, settingsModel)
+                    .listen((_) {
+                  _settingsBloc.loadSettings(_user);
+                });
+              }),
             ]);
           } else {
             return const Center(

--- a/lib/screens/settings_screens/settings_screen.dart
+++ b/lib/screens/settings_screens/settings_screen.dart
@@ -159,7 +159,7 @@ class SettingsScreen extends StatelessWidget {
                   settingsModel.showPopup = !settingsModel.showPopup;
                   _settingsBloc.updateSettings(_user.id, settingsModel)
                       .listen((_) {
-                    _settingsBloc.loadSettings(_user);
+                        _settingsBloc.loadSettings(_user);
                   });
                 }),
             ]);

--- a/lib/screens/settings_screens/settings_screen.dart
+++ b/lib/screens/settings_screens/settings_screen.dart
@@ -151,7 +151,7 @@ class SettingsScreen extends StatelessWidget {
                   settingsModel.pictogramText = !settingsModel.pictogramText;
                   _settingsBloc.updateSettings(_user.id, settingsModel)
                       .listen((_) {
-                    _settingsBloc.loadSettings(_user);
+                        _settingsBloc.loadSettings(_user);
                   });
                 }),
               SettingsCheckMarkButton.fromBoolean(
@@ -164,10 +164,10 @@ class SettingsScreen extends StatelessWidget {
                 }),
             ]);
           } else {
-            return const Center(
-              child: CircularProgressIndicator(),
-            );
-          }
+              return const Center(
+                child: CircularProgressIndicator(),
+              );
+            }
         });
   }
 
@@ -180,20 +180,20 @@ class SettingsScreen extends StatelessWidget {
             final SettingsModel _settingsModel = settingsSnapshot.data;
             return SettingsSection('Tid', <SettingsSectionItem>[
               SettingsCheckMarkButton.fromBoolean(
-                  _settingsModel.lockTimerControl, 'Lås tidsstyring', () {
-                _settingsModel.lockTimerControl =
-                !_settingsModel.lockTimerControl;
-                _settingsBloc.updateSettings(_user.id, _settingsModel)
-                    .listen((_) {
-                  _settingsBloc.loadSettings(_user);
-                });
+                _settingsModel.lockTimerControl, 'Lås tidsstyring', () {
+                  _settingsModel.lockTimerControl =
+                  !_settingsModel.lockTimerControl;
+                  _settingsBloc.updateSettings(_user.id, _settingsModel)
+                      .listen((_) {
+                        _settingsBloc.loadSettings(_user);
+                  });
               })
             ]);
           } else {
-            return const Center(
-              child: CircularProgressIndicator(),
-            );
-          }
+              return const Center(
+                child: CircularProgressIndicator(),
+              );
+            }
         });
   }
 
@@ -205,27 +205,23 @@ class SettingsScreen extends StatelessWidget {
 
   Widget _buildPrivacySection() {
     return StreamBuilder<SettingsModel>(
-        stream: _settingsBloc.settings,
-        builder: (BuildContext context,
-            AsyncSnapshot<SettingsModel> settingsSnapshot) {
+      stream: _settingsBloc.settings,
+      builder: (BuildContext context,
+        AsyncSnapshot<SettingsModel> settingsSnapshot) {
           return SettingsSection('Privatliv', <SettingsSectionItem>[
-            SettingsArrowButton(
-              'Privatlivsinformationer',
-                  () =>
-                      Routes.push(context, PrivacyInformationScreen())
-                          .then((Object object) =>
-                          _settingsBloc.loadSettings(_user)),
+            SettingsArrowButton('Privatlivsinformationer', () =>
+              Routes.push(context, PrivacyInformationScreen())
+                .then((Object object) => _settingsBloc.loadSettings(_user)),
             ),
           ]);
-
-        });
+      });
   }
 
   Widget _buildTimeRepresentationSettings(BuildContext context) {
     return StreamBuilder<SettingsModel>(
-        stream: _settingsBloc.settings,
-        builder: (BuildContext context,
-            AsyncSnapshot<SettingsModel> settingsSnapshot) {
+      stream: _settingsBloc.settings,
+      builder: (BuildContext context,
+        AsyncSnapshot<SettingsModel> settingsSnapshot) {
           if (settingsSnapshot.hasData) {
             final DefaultTimer userTimer = settingsSnapshot.data.defaultTimer;
             final SettingsModel settingsModel = settingsSnapshot.data;
@@ -251,10 +247,10 @@ class SettingsScreen extends StatelessWidget {
               )
             ]);
           } else {
-            return const Center(
-              child: CircularProgressIndicator(),
-            );
-          }
-        });
+              return const Center(
+                child: CircularProgressIndicator(),
+              );
+            }
+      });
   }
 }

--- a/lib/screens/settings_screens/settings_screen.dart
+++ b/lib/screens/settings_screens/settings_screen.dart
@@ -147,22 +147,21 @@ class SettingsScreen extends StatelessWidget {
                     : 'Mandag til søndag'),
               ),
               SettingsCheckMarkButton.fromBoolean(
-                  settingsModel.pictogramText, 'Piktogram tekst er synlig', () {
-                settingsModel.pictogramText = !settingsModel.pictogramText;
-                _settingsBloc.updateSettings(_user.id, settingsModel)
-                    .listen((_) {
-                  _settingsBloc.loadSettings(_user);
-                });
-              }),
+                settingsModel.pictogramText, 'Piktogram tekst er synlig', () {
+                  settingsModel.pictogramText = !settingsModel.pictogramText;
+                  _settingsBloc.updateSettings(_user.id, settingsModel)
+                      .listen((_) {
+                    _settingsBloc.loadSettings(_user);
+                  });
+                }),
               SettingsCheckMarkButton.fromBoolean(
-                //Ingen backend implementeret, KUN VISUELT
-                  settingsModel.pictogramText, 'Vis bekræftelse popups', () {
-                    //pictogramText skal erstattes med showPopup, som også skal laves i backend
-                _settingsBloc.updateSettings(_user.id, settingsModel)
-                    .listen((_) {
-                  _settingsBloc.loadSettings(_user);
-                });
-              }),
+                settingsModel.showPopup, 'Vis bekræftelse popups', () {
+                  settingsModel.showPopup = !settingsModel.showPopup;
+                  _settingsBloc.updateSettings(_user.id, settingsModel)
+                      .listen((_) {
+                    _settingsBloc.loadSettings(_user);
+                  });
+                }),
             ]);
           } else {
             return const Center(

--- a/lib/widgets/weekplanner_choiceboard_selector.dart
+++ b/lib/widgets/weekplanner_choiceboard_selector.dart
@@ -129,7 +129,8 @@ class WeekplannerChoiceboardSelector extends StatelessWidget {
            child: GestureDetector(
                onTap: () {
                  if(settingSnapshot.data.showPopup) {
-                   _selectPictogramFromChoiceBoardPopup(context, pictograms, index)
+                   _selectPictogramFromChoiceBoardPopup(context,
+                     pictograms, index)
                        .then((_) {
                    Routes.pop(context);
                  });

--- a/lib/widgets/weekplanner_choiceboard_selector.dart
+++ b/lib/widgets/weekplanner_choiceboard_selector.dart
@@ -138,32 +138,50 @@ class WeekplannerChoiceboardSelector extends StatelessWidget {
 
   Future<Center> _selectedPictogramFromChoiceBoard(
       BuildContext context, List<Widget> pictograms, int index) {
-    return showDialog<Center>(
-        barrierDismissible: false,
-        context: context,
-        builder: (BuildContext context) {
-          return GirafConfirmDialog(
-              key: const Key('PictogramSelectorConfirmDialog'),
-              title: 'Vælg aktivitet',
-              description: 'Vil du vælge aktiviteten ' +
-                  _activity.pictograms[index].title,
-              confirmButtonText: 'Ja',
-              confirmButtonIcon:
-                  const ImageIcon(AssetImage('assets/icons/accept.png')),
-              confirmOnPressed: () {
-                _activity.isChoiceBoard = false;
-                final List<PictogramModel> _pictogramModels = <PictogramModel>[
-                  _activity.pictograms[index]
-                ];
-                _activity.pictograms = _pictogramModels;
+    if(false) {
+      return showDialog<Center>(
+          barrierDismissible: false,
+          context: context,
+          builder: (BuildContext context) {
+            return GirafConfirmDialog(
+                key: const Key('PictogramSelectorConfirmDialog'),
+                title: 'Vælg aktivitet',
+                description: 'Vil du vælge aktiviteten ' +
+                    _activity.pictograms[index].title,
+                confirmButtonText: 'Ja',
+                confirmButtonIcon:
+                const ImageIcon(AssetImage('assets/icons/accept.png')),
+                confirmOnPressed: () {
+                  _activity.isChoiceBoard = false;
+                  final List<PictogramModel> _pictogramModels = <
+                      PictogramModel>[
+                    _activity.pictograms[index]
+                  ];
+                  _activity.pictograms = _pictogramModels;
 
-                _activityBloc.update();
-                _activityBloc.activityModelStream.skip(1).take(1).listen((_) {
-                  Routes.pop(context);
-                });
-                // Closes the dialog box
-              },
-              cancelOnPressed: () {});
-        });
+                  _activityBloc.update();
+                  _activityBloc.activityModelStream.skip(1).take(1).listen((_) {
+                    Routes.pop(context);
+                  });
+                  // Closes the dialog box
+                },
+                cancelOnPressed: () {});
+          });
+    }
+    else{
+      _activity.isChoiceBoard = false;
+      final List<PictogramModel> _pictogramModels = <
+          PictogramModel>[
+        _activity.pictograms[index]
+      ];
+      _activity.pictograms = _pictogramModels;
+
+      _activityBloc.update();
+      _activityBloc.load(_activity, _user);
+      //Refreshes weekplan to make the change visible to the citizen
+      _activityBloc.activityModelStream.skip(1).take(1).listen((_) {
+        Routes.pop(context);
+      });//Closes choiceboard
+    }
   }
 }

--- a/lib/widgets/weekplanner_choiceboard_selector.dart
+++ b/lib/widgets/weekplanner_choiceboard_selector.dart
@@ -21,6 +21,7 @@ class WeekplannerChoiceboardSelector extends StatelessWidget {
   WeekplannerChoiceboardSelector(this._activity, this._activityBloc,
       this._user) {
     _activityBloc.load(_activity, _user);
+    _settingsBloc.loadSettings(_user);
   }
 
   final ActivityModel _activity;

--- a/lib/widgets/weekplanner_choiceboard_selector.dart
+++ b/lib/widgets/weekplanner_choiceboard_selector.dart
@@ -5,6 +5,7 @@ import 'package:api_client/models/settings_model.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:weekplanner/blocs/activity_bloc.dart';
+import 'package:weekplanner/blocs/settings_bloc.dart';
 import 'package:weekplanner/blocs/pictogram_image_bloc.dart';
 import 'package:weekplanner/di.dart';
 import 'package:weekplanner/routes.dart';
@@ -27,6 +28,10 @@ class WeekplannerChoiceboardSelector extends StatelessWidget {
   final DisplayNameModel _user;
 
   final ActivityBloc _activityBloc;
+
+  /// The settings bloc which we get the settings from, you need to make sure
+  /// you have loaded settings into it before hand otherwise text is never build
+  final SettingsBloc _settingsBloc = di.getDependency<SettingsBloc>();
 
   @override
   Widget build(BuildContext context) {
@@ -113,6 +118,7 @@ class WeekplannerChoiceboardSelector extends StatelessWidget {
   Widget _displayPictogram(
       BuildContext context, List<Widget> pictograms, int index) {
    return StreamBuilder<SettingsModel>(
+     stream: _settingsBloc.settings,
      builder: (BuildContext context,
      AsyncSnapshot<SettingsModel> settingSnapshot) {
        return SizedBox(
@@ -122,9 +128,9 @@ class WeekplannerChoiceboardSelector extends StatelessWidget {
            child: GestureDetector(
                onTap: () {
                  if(settingSnapshot.data.showPopup) {
-                 _selectPictogramFromChoiceBoardPopup(context, pictograms, index)
-                     .then((_) {
-                 Routes.pop(context);
+                   _selectPictogramFromChoiceBoardPopup(context, pictograms, index)
+                       .then((_) {
+                   Routes.pop(context);
                  });
                  }
                  else{

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -20,7 +20,7 @@ packages:
     description:
       path: "."
       ref: develop
-      resolved-ref: a5611171295ca23e9d0ea7a28fd2cd9e3e548f32
+      resolved-ref: "1d3c1bfdd1cc6d31945e4e665dd637f95fb92cec"
       url: "https://github.com/aau-giraf/api_client.git"
     source: git
     version: "0.0.1"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -20,7 +20,7 @@ packages:
     description:
       path: "."
       ref: develop
-      resolved-ref: eeead44ceb373569e14f98178e6b014c3f01e499
+      resolved-ref: a5611171295ca23e9d0ea7a28fd2cd9e3e548f32
       url: "https://github.com/aau-giraf/api_client.git"
     source: git
     version: "0.0.1"

--- a/test/screens/settings_screens/color_theme_selection_screen_test.dart
+++ b/test/screens/settings_screens/color_theme_selection_screen_test.dart
@@ -77,7 +77,8 @@ void main() {
         nrOfDaysToDisplay: 1,
         pictogramText: false,
         weekDayColors: MockUserApi.createWeekDayColors(),
-        lockTimerControl: false);
+        lockTimerControl: false,
+        showPopup: false);
 
     when(api.user.updateSettings(any, any)).thenAnswer((_) {
       return Stream<bool>.value(true);

--- a/test/screens/settings_screens/settings_screen_test.dart
+++ b/test/screens/settings_screens/settings_screen_test.dart
@@ -81,6 +81,7 @@ void main() {
       weekDayColors: MockUserApi.createWeekDayColors(),
       lockTimerControl: false,
       pictogramText: false,
+      showPopup: false,
     );
 
     di.registerDependency<AuthBloc>((_) => AuthBloc(api));
@@ -149,6 +150,19 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(true, mockSettings.pictogramText);
+  });
+
+  testWidgets('Vis popup knap opdaterer indstillinger',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(MaterialApp(home: SettingsScreen(user)));
+        await tester.pumpAndSettle();
+
+        expect(false, mockSettings.showPopup);
+
+        await tester.tap(find.text('Vis bekræftelse popups'));
+        await tester.pumpAndSettle();
+
+        expect(true, mockSettings.showPopup);
   });
 
   testWidgets('Settings has TimerControl checkbox without an checkmark',


### PR DESCRIPTION
# Description
Added the showPopup setting in the usersettings. It is default off for every user, but can be toggled. When enabled, there are no popups for the choiceboard for the citizens.  There has also been added a unit test for toggling the setting. 


Fixes #673

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration*
This has been unit tested and acceptance tested locally using `sample-data`. It has not been tested online, as the server has had issues.

**Development Configuration**
* Flutter version: 2.0.5
* Dart version: 2.12.3

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas, if necessary
- [x] I have made corresponding changes to the documentation, if necessary
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have Acceptance Tested this on an iOS device
- [x] I have Acceptance Tested this on an Android device
