### PR TITLE
Feature/892

### DIFF
--- a/lib/blocs/pictogram_bloc.dart
+++ b/lib/blocs/pictogram_bloc.dart
@@ -25,6 +25,8 @@ class PictogramBloc extends BlocBase {
         extendSearch();
       }
     });
+    search('');
+
   }
 
   /// This stream is where all results from searching for pictograms are put in.
@@ -70,9 +72,9 @@ class PictogramBloc extends BlocBase {
   ///
   /// The results are published in [pictograms].
   void search(String query) {
-    if (query.isEmpty) {
+    /*if (query.isEmpty) {
       return;
-    }
+    }*/
 
     loadingPictograms = true;
     if (_debounceTimer != null) {

--- a/lib/blocs/pictogram_bloc.dart
+++ b/lib/blocs/pictogram_bloc.dart
@@ -74,11 +74,10 @@ search('');
   ///
   /// The results are published in [pictograms].
   void search(String query) {
-    /*if (query.isEmpty) {
-      return;
-    }*/
-    //ensures that it always starts with the  first pictograms
+
+    //ensures that it always shows the first pictograms in the database
     latestPage = 1;
+
     loadingPictograms = true;
     if (_debounceTimer != null) {
       _debounceTimer.cancel();

--- a/lib/blocs/pictogram_bloc.dart
+++ b/lib/blocs/pictogram_bloc.dart
@@ -15,17 +15,19 @@ const int pageSize = 24;
 
 /// Pictogram Business Logic Component
 class PictogramBloc extends BlocBase {
+
   /// Pictogram Business Logic Component
   ///
   /// Gives the ability to search for pictograms and await the results.
   PictogramBloc(this._api){
+
     // Listens for if view is scrolled to the bottom
     sc.addListener(() {
       if (sc.position.pixels >= sc.position.maxScrollExtent) {
         extendSearch();
       }
     });
-    search('');
+search('');
 
   }
 
@@ -75,7 +77,8 @@ class PictogramBloc extends BlocBase {
     /*if (query.isEmpty) {
       return;
     }*/
-
+    //ensures that it always starts with the  first pictograms
+    latestPage = 1;
     loadingPictograms = true;
     if (_debounceTimer != null) {
       _debounceTimer.cancel();
@@ -109,7 +112,7 @@ class PictogramBloc extends BlocBase {
   ///
   /// The results are published in [pictograms].
   void extendSearch() {
-    if (reachedLastPictogram || latestQuery == null || latestQuery.isEmpty) {
+    if (reachedLastPictogram || latestQuery == null) {
       return;
     }
 

--- a/lib/blocs/pictogram_bloc.dart
+++ b/lib/blocs/pictogram_bloc.dart
@@ -27,8 +27,6 @@ class PictogramBloc extends BlocBase {
         extendSearch();
       }
     });
-search('');
-
   }
 
   /// This stream is where all results from searching for pictograms are put in.
@@ -87,6 +85,7 @@ search('');
     List<PictogramModel> _resultPlaceholder;
     _debounceTimer = Timer(const Duration(milliseconds: _debounceTime), () {
       //Timer for sending an error if getting pictogram results takes too long
+
       Timer(const Duration(milliseconds: _timeoutTime), () {
         if (_resultPlaceholder == null || _resultPlaceholder.isEmpty) {
           _pictograms.addError('Søgningen gav ingen resultater. '

--- a/lib/blocs/pictogram_image_bloc.dart
+++ b/lib/blocs/pictogram_image_bloc.dart
@@ -17,11 +17,11 @@ class PictogramImageBloc extends BlocBase {
   /// Provides loaded pictogram-images
   Stream<Image> get image => _image.stream;
 
-
   final rx_dart.BehaviorSubject<Image> _image
   = rx_dart.BehaviorSubject<Image>();
 
   Stream<String> get title => _title.stream;
+
   final rx_dart.BehaviorSubject<String> _title
   = rx_dart.BehaviorSubject<String>();
 
@@ -31,6 +31,7 @@ class PictogramImageBloc extends BlocBase {
   static final Queue<int> _cacheQueue = Queue<int>();
   static const int _cacheMaxSize = 100;
 
+
   /// Lock for adding pictograms to cache
   static Mutex lock = Mutex();
 
@@ -39,6 +40,9 @@ class PictogramImageBloc extends BlocBase {
   /// The [pictogram] model should contain an ID which the API can then fetch.
   void load(PictogramModel pictogram) {
     _api.pictogram.getImage(pictogram.id).listen(_image.add);
+  }
+
+  void loadTitle(PictogramModel pictogram){
     _api.pictogram.getTitle(pictogram.id).listen(_title.add);
   }
 

--- a/lib/blocs/pictogram_image_bloc.dart
+++ b/lib/blocs/pictogram_image_bloc.dart
@@ -17,8 +17,13 @@ class PictogramImageBloc extends BlocBase {
   /// Provides loaded pictogram-images
   Stream<Image> get image => _image.stream;
 
+
   final rx_dart.BehaviorSubject<Image> _image
   = rx_dart.BehaviorSubject<Image>();
+
+  Stream<String> get title => _title.stream;
+  final rx_dart.BehaviorSubject<String> _title
+  = rx_dart.BehaviorSubject<String>();
 
   final Api _api;
 
@@ -34,6 +39,7 @@ class PictogramImageBloc extends BlocBase {
   /// The [pictogram] model should contain an ID which the API can then fetch.
   void load(PictogramModel pictogram) {
     _api.pictogram.getImage(pictogram.id).listen(_image.add);
+    _api.pictogram.getTitle(pictogram.id).listen(_title.add);
   }
 
   /// Initialize loading of a specific [PictogramModel] from its [id].
@@ -92,5 +98,6 @@ class PictogramImageBloc extends BlocBase {
   @override
   void dispose() {
     _image.close();
+    _title.close();
   }
 }

--- a/lib/blocs/pictogram_image_bloc.dart
+++ b/lib/blocs/pictogram_image_bloc.dart
@@ -20,11 +20,6 @@ class PictogramImageBloc extends BlocBase {
   final rx_dart.BehaviorSubject<Image> _image
   = rx_dart.BehaviorSubject<Image>();
 
-  Stream<String> get title => _title.stream;
-
-  final rx_dart.BehaviorSubject<String> _title
-  = rx_dart.BehaviorSubject<String>();
-
   final Api _api;
 
   static final Map<int, Image> _cache = <int, Image>{};
@@ -40,10 +35,6 @@ class PictogramImageBloc extends BlocBase {
   /// The [pictogram] model should contain an ID which the API can then fetch.
   void load(PictogramModel pictogram) {
     _api.pictogram.getImage(pictogram.id).listen(_image.add);
-  }
-
-  void loadTitle(PictogramModel pictogram){
-    _api.pictogram.getTitle(pictogram.id).listen(_title.add);
   }
 
   /// Initialize loading of a specific [PictogramModel] from its [id].
@@ -102,6 +93,5 @@ class PictogramImageBloc extends BlocBase {
   @override
   void dispose() {
     _image.close();
-    _title.close();
   }
 }

--- a/lib/screens/pictogram_search_screen.dart
+++ b/lib/screens/pictogram_search_screen.dart
@@ -79,7 +79,8 @@ class _PictogramSearchState extends State<PictogramSearch> {
                                     .map((PictogramModel pictogram)
                                 => PictogramImage(
                                     pictogram: pictogram,
-                                    haveRights: widget.user == null || pictogram.userId
+                                    haveRights: widget.user == null
+                                        || pictogram.userId
                                         == null ? false :
                                     pictogram.userId == widget.user.id,
                                     needsTitle: true,

--- a/lib/screens/pictogram_search_screen.dart
+++ b/lib/screens/pictogram_search_screen.dart
@@ -15,15 +15,28 @@ import '../style/custom_color.dart' as theme;
 ///
 /// This screen will return `null` back is pressed, otherwise it will return the
 /// chosen pictogram.
-class PictogramSearch extends StatelessWidget {
+class PictogramSearch extends StatefulWidget {
 
   /// Constructor
   PictogramSearch({@required this.user});
 
-  final PictogramBloc _bloc = di.getDependency<PictogramBloc>();
-
   /// The current authenticated user
   final DisplayNameModel user;
+
+  @override
+  _PictogramSearchState createState() => _PictogramSearchState();
+}
+
+class _PictogramSearchState extends State<PictogramSearch> {
+  final PictogramBloc _bloc = di.getDependency<PictogramBloc>();
+
+
+  //Search after pictograms when the page loads
+  @override
+  void initState(){
+    super.initState();
+    _bloc.search('');
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -66,9 +79,9 @@ class PictogramSearch extends StatelessWidget {
                                     .map((PictogramModel pictogram)
                                 => PictogramImage(
                                     pictogram: pictogram,
-                                    haveRights: user == null || pictogram.userId
+                                    haveRights: widget.user == null || pictogram.userId
                                         == null ? false :
-                                    pictogram.userId == user.id,
+                                    pictogram.userId == widget.user.id,
                                     onPressed: () =>
                                         Routes.pop(context, pictogram)))
                                     .toList(),

--- a/lib/screens/pictogram_search_screen.dart
+++ b/lib/screens/pictogram_search_screen.dart
@@ -82,6 +82,7 @@ class _PictogramSearchState extends State<PictogramSearch> {
                                     haveRights: widget.user == null || pictogram.userId
                                         == null ? false :
                                     pictogram.userId == widget.user.id,
+                                    needsTitle: true,
                                     onPressed: () =>
                                         Routes.pop(context, pictogram)))
                                     .toList(),

--- a/lib/screens/pictogram_search_screen.dart
+++ b/lib/screens/pictogram_search_screen.dart
@@ -18,7 +18,7 @@ import '../style/custom_color.dart' as theme;
 class PictogramSearch extends StatefulWidget {
 
   /// Constructor
-  PictogramSearch({@required this.user});
+  const PictogramSearch({@required this.user});
 
   /// The current authenticated user
   final DisplayNameModel user;

--- a/lib/widgets/input_fields_weekplan.dart
+++ b/lib/widgets/input_fields_weekplan.dart
@@ -170,7 +170,7 @@ class InputFieldsWeekPlanState extends State<InputFieldsWeekPlan> {
   }
 
   void _openPictogramSearch(BuildContext context, NewWeekplanBloc bloc) {
-    Routes.push<PictogramModel>(context, PictogramSearch(user: null,))
+    Routes.push<PictogramModel>(context, const PictogramSearch(user: null,))
         .then((PictogramModel pictogram) {
       if (pictogram != null) {
         bloc.onThumbnailChanged.add(pictogram);

--- a/lib/widgets/pictogram_image.dart
+++ b/lib/widgets/pictogram_image.dart
@@ -78,16 +78,6 @@ class PictogramImage extends StatelessWidget {
         });
   }
 
-  ///Loads the title of the pictograms and displays them
-  Widget showTitle() {
-    _bloc.loadTitle(pictogram);
-    return StreamBuilder<String>(
-        stream: _bloc.title,
-        builder: (BuildContext context, AsyncSnapshot<String> snapshot) =>
-            //Display the title, if it is null display nothing
-            Text(snapshot.data ?? '')
-    );
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -110,7 +100,7 @@ class PictogramImage extends StatelessWidget {
                                 builder: (BuildContext context,
                                         AsyncSnapshot<Image> snapshot) =>
                                     snapshot.data ?? _loading),
-                            showTitle(),
+                        Text(pictogram.title),
                           ]
                           ):
                           StreamBuilder<Image>(
@@ -118,6 +108,7 @@ class PictogramImage extends StatelessWidget {
                               builder: (BuildContext context,
                                   AsyncSnapshot<Image> snapshot) =>
                               snapshot.data ?? _loading),
+                          //delete button
                           haveRights
                               ? Positioned(
                                   top: 5,

--- a/lib/widgets/pictogram_image.dart
+++ b/lib/widgets/pictogram_image.dart
@@ -1,3 +1,4 @@
+
 import 'package:flutter/material.dart';
 import 'package:weekplanner/blocs/pictogram_image_bloc.dart';
 import 'package:weekplanner/di.dart';
@@ -15,17 +16,18 @@ class PictogramImage extends StatelessWidget {
   /// authenticated request is then made to the back-end to load the image.
   ///
   /// The [onPressed] function will be called every time the image is pressed
-  PictogramImage({
-    Key key,
-    @required this.pictogram,
-    @required this.onPressed,
-    this.haveRights = false
-  }) : super(key: key) {
+  PictogramImage(
+      {Key key,
+      @required this.pictogram,
+      @required this.onPressed,
+      this.haveRights = false})
+      : super(key: key) {
     _bloc.load(pictogram);
   }
 
   /// Provided Pictogram to load
   final PictogramModel pictogram;
+
   /// haveRights returns true if the current active user have the rights to the
   /// pictogram.
   final bool haveRights;
@@ -35,79 +37,85 @@ class PictogramImage extends StatelessWidget {
   final VoidCallback onPressed;
 
   final PictogramImageBloc _bloc = di.getDependency<PictogramImageBloc>();
+
+
   final Widget _loading = Center(
       child: Container(
-          width: 100, height: 100, child: const CircularProgressIndicator()
-      )
-  );
+          width: 100, height: 100, child: const CircularProgressIndicator()));
 
-  Future<Center> _confirmDeleteDialog(
-      BuildContext context
-      ){
+  Future<Center> _confirmDeleteDialog(BuildContext context) {
     return showDialog<Center>(
         context: context,
         barrierDismissible: false,
-        builder: (BuildContext context){
+        builder: (BuildContext context) {
           return GirafConfirmDialog(
               title: 'Slet piktogram',
               description: 'Vil du slette det markerede piktogram?',
               confirmButtonText: 'Slet',
-              confirmButtonIcon: const ImageIcon(AssetImage('assets/icons/delete.png')),
-              confirmOnPressed: (){
-
-                if (!_bloc.delete(pictogram)){
+              confirmButtonIcon:
+                  const ImageIcon(AssetImage('assets/icons/delete.png')),
+              confirmOnPressed: () {
+                if (!_bloc.delete(pictogram)) {
                   _notifyErrorOnDeleteDialog(context);
                 }
                 Routes.pop(context);
-              }
-          );
-        }
-    );
+              });
+        });
   }
 
-  Future<Center> _notifyErrorOnDeleteDialog(BuildContext context){
+  Future<Center> _notifyErrorOnDeleteDialog(BuildContext context) {
     return showDialog<Center>(
-      context: context,
-      barrierDismissible: false,
-      builder: (BuildContext context){
-        return const GirafNotifyDialog(
-          title: 'Det valgte piktogram kunne ikke slettes',
-          description: 'Piktogrammet kunne ikke slettes, prøv igen. '
-              'Hvis fejlen gentager sig, kontakt en administrator.',
-        );
-      }
-    );
+        context: context,
+        barrierDismissible: false,
+        builder: (BuildContext context) {
+          return const GirafNotifyDialog(
+            title: 'Det valgte piktogram kunne ikke slettes',
+            description: 'Piktogrammet kunne ikke slettes, prøv igen. '
+                'Hvis fejlen gentager sig, kontakt en administrator.',
+          );
+        });
   }
 
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
-      onTap: onPressed,
-      child: Card(
-        child: FittedBox(
-          fit: BoxFit.contain,
-          child: Container(
-            child: Directionality(
-              textDirection: TextDirection.ltr,
-              child: Stack(
-                children: <Widget>[
-                   StreamBuilder<Image>(
-                    stream: _bloc.image,
-                    builder:
-                      (BuildContext context, AsyncSnapshot<Image> snapshot) =>
-                      snapshot.data ?? _loading),
-              haveRights ? Positioned(
-                top: 5,
-                right: 5,
-                child: GirafButton(
-                  onPressed: () {_confirmDeleteDialog(context);},
-                  icon: const ImageIcon(AssetImage('assets/icons/gallery.png')),
-                  text: 'Slet',
-                ),
-              ) : Container(),
-          ])
+        onTap: onPressed,
+        child: Card(
+            child: FittedBox(
+                fit: BoxFit.contain,
+                child: Container(
+                    child: Directionality(
+                        textDirection: TextDirection.ltr,
+                        child: Stack(children: <Widget>[
+                          //The column contains the pictogram image and title
+                          Column(children: <Widget>[
+                            StreamBuilder<Image>(
+                                stream: _bloc.image,
+                                builder: (BuildContext context,
+                                        AsyncSnapshot<Image> snapshot) =>
+                                    snapshot.data ?? _loading),
+
+                        StreamBuilder<String>(
+                            stream: _bloc.title,
+                            builder: (BuildContext context,
+                                AsyncSnapshot<String> snapshot) =>
+                                Text(snapshot.data??'')),
+                          ]),
+                          haveRights ? Positioned(
+                            top: 5,
+                            right: 5,
+                            child: GirafButton(
+                              onPressed: () {_confirmDeleteDialog(context);},
+                              icon: const ImageIcon(AssetImage('assets/icons/gallery.png')),
+                              text: 'Slet',
+                            ),
+                          ) : Container(),
+                        ]
+                        )
+                    )
+                )
+            )
         )
-    )
-    )));
+    );
   }
 }

--- a/lib/widgets/pictogram_image.dart
+++ b/lib/widgets/pictogram_image.dart
@@ -87,19 +87,21 @@ class PictogramImage extends StatelessWidget {
                     child: Directionality(
                         textDirection: TextDirection.ltr,
                         child: Stack(children: <Widget>[
-                          //The column contains the pictogram image and title
+                          //The column widget contains the pictogram image and title
                           Column(children: <Widget>[
                             StreamBuilder<Image>(
                                 stream: _bloc.image,
                                 builder: (BuildContext context,
                                         AsyncSnapshot<Image> snapshot) =>
                                     snapshot.data ?? _loading),
-
                         StreamBuilder<String>(
                             stream: _bloc.title,
                             builder: (BuildContext context,
                                 AsyncSnapshot<String> snapshot) =>
+                            //Display the title, if it is null display nothing
                                 Text(snapshot.data??'')),
+
+
                           ]),
                           haveRights ? Positioned(
                             top: 5,

--- a/lib/widgets/pictogram_image.dart
+++ b/lib/widgets/pictogram_image.dart
@@ -43,7 +43,7 @@ class PictogramImage extends StatelessWidget {
 
   final Widget _loading = Center(
       child: Container(
-          width: 100, height: 100, child: const CircularProgressIndicator()));
+          width: 200, height: 200, child: const CircularProgressIndicator()));
 
   Future<Center> _confirmDeleteDialog(BuildContext context) {
     return showDialog<Center>(
@@ -95,11 +95,18 @@ class PictogramImage extends StatelessWidget {
                           needsTitle
                               ? Column(
                               children: <Widget>[
-                                StreamBuilder<Image>(
-                                stream: _bloc.image,
-                                builder: (BuildContext context,
-                                        AsyncSnapshot<Image> snapshot) =>
-                                    snapshot.data ?? _loading),
+                                Stack(children:  <Widget>[
+                                  Container(
+                                    //200x200 is the size of the pictograms,
+                                    //this is added so the text does not scale
+                                    width:200,
+                                    height: 200,
+                                  ),
+                                  StreamBuilder<Image>(
+                                      stream: _bloc.image,
+                                      builder: (BuildContext context,
+                                          AsyncSnapshot<Image> snapshot) =>
+                                      snapshot.data ?? _loading)]),
                         Text(pictogram.title),
                           ]
                           ):

--- a/test/screens/edit_weekplan_screen_test.dart
+++ b/test/screens/edit_weekplan_screen_test.dart
@@ -58,7 +58,7 @@ class MockPictogramApi extends Mock implements PictogramApi {}
 final PictogramModel mockPictogram = PictogramModel(
     id: 1,
     lastEdit: null,
-    title: null,
+    title: 'title',
     accessLevel: null,
     imageUrl: 'http://any.tld',
     imageHash: null);
@@ -320,6 +320,11 @@ void main() {
 
     testWidgets('Click on thumbnail redirects to pictogram search screen',
         (WidgetTester tester) async {
+
+          when(api.pictogram.getAll(page: 1,
+              pageSize: pageSize, query: '')).thenAnswer(
+                  (_) => rx_dart.BehaviorSubject<List<PictogramModel>>.seeded(
+                  <PictogramModel>[mockPictogram]));
       mockBloc.acceptAllInputs = true;
       await tester.pumpWidget(
         MaterialApp(
@@ -334,7 +339,10 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.byType(PictogramSearch), findsOneWidget);
-    });
+
+          await tester.pump(const Duration(milliseconds: 11000));
+
+        });
   });
 
   group('Edit weekplan overwriting', () {

--- a/test/screens/new_weekplan_screen_test.dart
+++ b/test/screens/new_weekplan_screen_test.dart
@@ -58,7 +58,7 @@ class MockPictogramApi extends Mock implements PictogramApi {}
 final PictogramModel mockPictogram = PictogramModel(
     id: 1,
     lastEdit: null,
-    title: null,
+    title: 'title',
     accessLevel: null,
     imageUrl: 'http://any.tld',
     imageHash: null);
@@ -307,6 +307,10 @@ void main() {
 
   testWidgets('Click on thumbnail redirects to pictogram search screen',
           (WidgetTester tester) async {
+            when(api.pictogram.getAll(page: 1,
+                pageSize: pageSize, query: '')).thenAnswer(
+                    (_) => rx_dart.BehaviorSubject<List<PictogramModel>>.seeded(
+                    <PictogramModel>[mockPictogram]));
         mockBloc.acceptAllInputs = true;
         await tester.pumpWidget(
           MaterialApp(
@@ -320,7 +324,9 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(find.byType(PictogramSearch), findsOneWidget);
-      });
+            await tester.pump(const Duration(milliseconds: 11000));
+
+          });
 
   testWidgets(
       'Click on save weekplan button saves weekplan and return saved weekplan',

--- a/test/screens/pictogram_search_screen_test.dart
+++ b/test/screens/pictogram_search_screen_test.dart
@@ -59,8 +59,6 @@ void main() {
 
   testWidgets('Camera button shows', (WidgetTester tester) async {
 
-    //final Completer<bool> done = Completer<bool>();
-
     when(pictogramApi.getAll(page: bloc.latestPage,
         pageSize: pageSize, query: '')).thenAnswer(
             (_) => rx_dart.BehaviorSubject<List<PictogramModel>>.seeded(

--- a/test/screens/pictogram_search_screen_test.dart
+++ b/test/screens/pictogram_search_screen_test.dart
@@ -58,22 +58,55 @@ void main() {
   });
 
   testWidgets('Camera button shows', (WidgetTester tester) async {
+
+    //final Completer<bool> done = Completer<bool>();
+
+    when(pictogramApi.getAll(page: bloc.latestPage,
+        pageSize: pageSize, query: '')).thenAnswer(
+            (_) => rx_dart.BehaviorSubject<List<PictogramModel>>.seeded(
+            <PictogramModel>[pictogramModel]));
+
     await tester.pumpWidget(MaterialApp(
       home: PictogramSearch(user: user),
     ));
     await tester.pumpAndSettle();
 
     expect(find.text('Tag billede'), findsOneWidget);
+
+    await tester.pump(const Duration(milliseconds: 11000));
+
+
   });
 
   testWidgets('renders', (WidgetTester tester) async {
+    final Completer<bool> done = Completer<bool>();
+
+    when(pictogramApi.getAll(page: bloc.latestPage,
+        pageSize: pageSize, query: '')).thenAnswer(
+            (_) => rx_dart.BehaviorSubject<List<PictogramModel>>.seeded(
+            <PictogramModel>[pictogramModel]));
+
     await tester.pumpWidget(MaterialApp(
         home: PictogramSearch(
       user: user,
     )));
+
+    await tester.pump(const Duration(milliseconds: 41000));
+
+    bloc.pictograms.listen((List<PictogramModel> images) async {
+      await tester.pump();
+      expect(find.byType(PictogramImage), findsNWidgets(1));
+      done.complete(true);
+    });
+    await done.future;
   });
 
   testWidgets('Has Giraf App Bar', (WidgetTester tester) async {
+    when(pictogramApi.getAll(page: bloc.latestPage,
+        pageSize: pageSize, query: '')).thenAnswer(
+            (_) => rx_dart.BehaviorSubject<List<PictogramModel>>.seeded(
+            <PictogramModel>[pictogramModel]));
+
     await tester.pumpWidget(MaterialApp(
         home: PictogramSearch(
       user: user,
@@ -81,6 +114,8 @@ void main() {
 
     expect(find.byWidgetPredicate((Widget widget) => widget is GirafAppBar),
         findsOneWidget);
+
+    await tester.pump(const Duration(milliseconds: 11000));
   });
 
   testWidgets('Display spinner on loading', (WidgetTester tester) async {

--- a/test/screens/weekplan_screen_test.dart
+++ b/test/screens/weekplan_screen_test.dart
@@ -1,3 +1,4 @@
+import 'package:api_client/api/pictogram_api.dart';
 import 'package:api_client/api_client.dart';
 import 'package:api_client/models/activity_model.dart';
 import 'package:api_client/models/displayname_model.dart';
@@ -11,6 +12,7 @@ import 'package:api_client/models/weekday_color_model.dart';
 import 'package:api_client/models/weekday_model.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
 import 'package:rflutter_alert/rflutter_alert.dart';
 import 'package:weekplanner/blocs/activity_bloc.dart';
 import 'package:weekplanner/blocs/auth_bloc.dart';
@@ -34,6 +36,7 @@ import 'package:weekplanner/widgets/giraf_copy_activities_dialog.dart';
 import 'package:weekplanner/widgets/pictogram_text.dart';
 import 'package:weekplanner/widgets/weekplan_screen_widgets/activity_card.dart';
 import 'package:weekplanner/widgets/weekplan_screen_widgets/weekplan_day_column.dart';
+import 'package:rxdart/rxdart.dart' as rx_dart;
 
 import '../mock_data.dart';
 
@@ -45,6 +48,7 @@ void main() {
   DisplayNameModel user;
   WeekplanBloc weekplanBloc;
   AuthBloc authBloc;
+  Api api;
 
   setUp(() {
     MockData mockData;
@@ -54,8 +58,8 @@ void main() {
     mockActivities = mockData.mockActivities;
     mockPictograms = mockData.mockPictograms;
     user = mockData.mockUser;
-
-    final Api api = mockData.mockApi;
+api = mockData.mockApi;
+api.pictogram=MockPictogramApi();
 
     authBloc = AuthBloc(api);
     authBloc.setMode(WeekplanMode.guardian);
@@ -740,6 +744,13 @@ void main() {
   });
 
   testWidgets('Add Activity buttons work', (WidgetTester tester) async {
+
+    when(api.pictogram.getAll(page: 1,
+        pageSize: pageSize, query: '')).thenAnswer(
+            (_) => rx_dart.BehaviorSubject<List<PictogramModel>>.seeded(
+            <PictogramModel>[mockPictograms[0]]));
+
+
     mockSettings.nrOfDaysToDisplay = 7;
     await tester.pumpWidget(MaterialApp(home: WeekplanScreen(mockWeek, user)));
     await tester.pumpAndSettle();
@@ -750,6 +761,8 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byType(PictogramSearch), findsOneWidget);
+    await tester.pump(const Duration(milliseconds: 11000));
+
   });
 
   testWidgets('Completed activities displayed correctly in Guardian Mode',

--- a/test/screens/weekplan_screen_test.dart
+++ b/test/screens/weekplan_screen_test.dart
@@ -1,4 +1,3 @@
-import 'package:api_client/api/pictogram_api.dart';
 import 'package:api_client/api_client.dart';
 import 'package:api_client/models/activity_model.dart';
 import 'package:api_client/models/displayname_model.dart';


### PR DESCRIPTION
# Description

It now loads all the pictograms when you enter the Pictogram Search Screen(it loads 24, and when you scolll to the bottom, it loads 24 more....)
It also loads all the pictograms again, when you clear the search field
All pictograms in the screen now have their title displayed
Fixed an error, that made the Pictogram Search Screen load the wrong pictograms( the wrong 24 pictograms, which had something to do with the latestPage variable not resetting when searching)

Changed some unittest, so that they would not fail with the new changes

Fixes #\892  (web-api issue, but did not change web-api)
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Changed a unittest, so it checks whether there is a pictogram when the page renders( see the test 'renders')
and of course manually tested it by looking if it works


**Development Configuration**
*Type "flutter --version" and "dart --version" in your CMD to check versions.*

* Flutter version: 2.0.5
* Dart version: 2.12.3

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas, if necessary
- [ ] I have made corresponding changes to the documentation, if necessary
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have Acceptance Tested this on an iOS device
- [ ] I have Acceptance Tested this on an Android device
