### PR TITLE
Logged in citizen skips choose citizen screen and are presented with the week plan selection screen - Feature/888v2

### DIFF
--- a/.github/workflows/Flutter-Verify.yml
+++ b/.github/workflows/Flutter-Verify.yml
@@ -4,7 +4,7 @@ on: [push]
 
 env:
   flutter_channel: 'stable'
-  flutter_version: '1.20.x'
+  flutter_version: '2.0.5'
   java_version: '12.x'
 
 jobs:

--- a/.github/workflows/Flutter-Verify.yml
+++ b/.github/workflows/Flutter-Verify.yml
@@ -39,6 +39,8 @@ jobs:
           path: ${{ matrix.flutter_path }}
       - run: flutter pub get
         name: Get dependencies
+      - run: flutter pub upgrade api_client
+        name: Upgrade api_client package
 
       - run: flutter doctor
         name: Doctor

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -149,7 +149,7 @@ linter:
     - recursive_getters
     - slash_for_doc_comments
     - sort_constructors_first
-    - sort_pub_dependencies
+    # - sort_pub_dependencies
     - sort_unnamed_constructors_first
     # - super_goes_last # no longer needed w/ Dart 2
     - test_types_in_equals

--- a/lib/blocs/timer_bloc.dart
+++ b/lib/blocs/timer_bloc.dart
@@ -96,7 +96,7 @@ class TimerBloc extends BlocBase {
   }
 
   List<int> _durationToTimestamp(Duration duration) {
-    final List<int> timestamp = List<int>(3);
+    final List<int> timestamp = List<int>.filled(3, 0);
     timestamp[0] = duration.inHours;
     timestamp[1] = duration.inMinutes.remainder(60);
     timestamp[2] = duration.inSeconds.remainder(60);

--- a/lib/blocs/toolbar_bloc.dart
+++ b/lib/blocs/toolbar_bloc.dart
@@ -4,7 +4,6 @@ import 'package:api_client/models/displayname_model.dart';
 import 'package:api_client/models/enums/role_enum.dart';
 import 'package:api_client/models/giraf_user_model.dart';
 import 'package:flutter/material.dart';
-import 'package:quiver/time.dart';
 import 'package:rflutter_alert/rflutter_alert.dart';
 import 'package:rxdart/rxdart.dart' as rx_dart;
 import 'package:weekplanner/blocs/auth_bloc.dart';
@@ -55,7 +54,7 @@ class ToolbarBloc extends BlocBase {
 
   /// Find the icon picture based on the input enum
   void _addIconButton(List<IconButton> _iconsToAdd, AppBarIcon icon,
-      VoidCallback callback, BuildContext context) async {
+      VoidCallback callback, BuildContext context) {
     switch (icon) {
       case AppBarIcon.accept:
         _iconsToAdd.add(_createIconAccept(callback));
@@ -82,7 +81,7 @@ class ToolbarBloc extends BlocBase {
         _iconsToAdd.add(_createIconChangeToCitizen(context));
         break;
       case AppBarIcon.changeToGuardian:
-        await _setUserNameOfGuardian();
+        _setUserNameOfGuardian();
         _iconsToAdd.add(_createIconChangeToGuardian(context));
         break;
       case AppBarIcon.copy:

--- a/lib/blocs/toolbar_bloc.dart
+++ b/lib/blocs/toolbar_bloc.dart
@@ -241,7 +241,7 @@ class ToolbarBloc extends BlocBase {
                     .style,
                 children: <TextSpan>[
                   TextSpan(
-                      text: _authBloc.loggedInUsername,
+                      text: _authBloc.loggedInUser.username,
                       style: const TextStyle(fontWeight: FontWeight.bold)),
                 ],
               ),
@@ -266,7 +266,7 @@ class ToolbarBloc extends BlocBase {
                 ? () {
               if (_clickable) {
                 _clickable = false;
-                loginFromPopUp(context, _authBloc.loggedInUsername,
+                loginFromPopUp(context, _authBloc.loggedInUser.username,
                     passwordCtrl.value.text);
                 // Timer makes it clicable again after 2 seconds.
                 Timer(const Duration(milliseconds: 2000), () {

--- a/lib/blocs/toolbar_bloc.dart
+++ b/lib/blocs/toolbar_bloc.dart
@@ -299,27 +299,29 @@ class ToolbarBloc extends BlocBase {
   Future<void> _setUserNameOfGuardian() async {
     final Completer<void> completer = Completer<void>();
 
-    switch (_authBloc.loggedInUser.role) {
-      case Role.Citizen:
-        // Get guardians for logged in citizen
-        _api.user.getGuardians(_authBloc.loggedInUser.id)
-          .listen((List<DisplayNameModel> event) {
-            // DisplayNameModel does not have userName, only displayName
-            // Therefore use id to set userName of guardian
-            _api.user.get(event.first.id).listen((GirafUserModel event) {
-              _userNameOfGuardian = event.username;  
-            }).onError((Object error) {
-              completer.completeError(error);
-            });
-        }).onError((Object error) {
-          completer.completeError(error);
-        });
-        break;
-      case Role.Guardian:
-        _userNameOfGuardian = _authBloc.loggedInUser.username;
-        break;
-      default:
-        break;
+    if (_authBloc.loggedInUser?.role != null) {
+      switch (_authBloc.loggedInUser.role) {
+        case Role.Citizen:
+          // Get guardians for logged in citizen
+          _api.user.getGuardians(_authBloc.loggedInUser.id)
+            .listen((List<DisplayNameModel> event) {
+              // DisplayNameModel does not have userName, only displayName
+              // Therefore use id to set userName of guardian
+              _api.user.get(event.first.id).listen((GirafUserModel event) {
+                _userNameOfGuardian = event.username;  
+              }).onError((Object error) {
+                completer.completeError(error);
+              });
+          }).onError((Object error) {
+            completer.completeError(error);
+          });
+          break;
+        case Role.Guardian:
+          _userNameOfGuardian = _authBloc.loggedInUser.username;
+          break;
+        default:
+          break;
+      }
     }
 
     completer.complete();

--- a/lib/blocs/toolbar_bloc.dart
+++ b/lib/blocs/toolbar_bloc.dart
@@ -1,5 +1,10 @@
 import 'dart:async';
+import 'package:api_client/api/api.dart';
+import 'package:api_client/models/displayname_model.dart';
+import 'package:api_client/models/enums/role_enum.dart';
+import 'package:api_client/models/giraf_user_model.dart';
 import 'package:flutter/material.dart';
+import 'package:quiver/time.dart';
 import 'package:rflutter_alert/rflutter_alert.dart';
 import 'package:rxdart/rxdart.dart' as rx_dart;
 import 'package:weekplanner/blocs/auth_bloc.dart';
@@ -26,6 +31,10 @@ class ToolbarBloc extends BlocBase {
   Stream<List<IconButton>> get visibleButtons => _visibleButtons.stream;
 
   final AuthBloc _authBloc = di.getDependency<AuthBloc>();
+  final Api _api = di.getDependency<Api>();
+
+  /// Store guardian user name related to logged in user.
+  String _userNameOfGuardian;
 
   //// Based on a list of the enum AppBarIcon this method populates a list of IconButtons to render in the nav-bar
   void updateIcons(Map<AppBarIcon, VoidCallback> icons, BuildContext context) {
@@ -46,7 +55,7 @@ class ToolbarBloc extends BlocBase {
 
   /// Find the icon picture based on the input enum
   void _addIconButton(List<IconButton> _iconsToAdd, AppBarIcon icon,
-      VoidCallback callback, BuildContext context) {
+      VoidCallback callback, BuildContext context) async {
     switch (icon) {
       case AppBarIcon.accept:
         _iconsToAdd.add(_createIconAccept(callback));
@@ -73,6 +82,7 @@ class ToolbarBloc extends BlocBase {
         _iconsToAdd.add(_createIconChangeToCitizen(context));
         break;
       case AppBarIcon.changeToGuardian:
+        await _setUserNameOfGuardian();
         _iconsToAdd.add(_createIconChangeToGuardian(context));
         break;
       case AppBarIcon.copy:
@@ -241,7 +251,7 @@ class ToolbarBloc extends BlocBase {
                     .style,
                 children: <TextSpan>[
                   TextSpan(
-                      text: _authBloc.loggedInUser.username,
+                      text: _userNameOfGuardian,
                       style: const TextStyle(fontWeight: FontWeight.bold)),
                 ],
               ),
@@ -266,7 +276,7 @@ class ToolbarBloc extends BlocBase {
                 ? () {
               if (_clickable) {
                 _clickable = false;
-                loginFromPopUp(context, _authBloc.loggedInUser.username,
+                loginFromPopUp(context, _userNameOfGuardian,
                     passwordCtrl.value.text);
                 // Timer makes it clicable again after 2 seconds.
                 Timer(const Duration(milliseconds: 2000), () {
@@ -283,6 +293,38 @@ class ToolbarBloc extends BlocBase {
             color: theme.GirafColors.dialogButton,
           )
         ]);
+  }
+
+  /// Set user name of the guardian that is related to logged in user
+  Future<void> _setUserNameOfGuardian() async {
+    final Completer<void> completer = Completer<void>();
+
+    switch (_authBloc.loggedInUser.role) {
+      case Role.Citizen:
+        // Get guardians for logged in citizen
+        _api.user.getGuardians(_authBloc.loggedInUser.id)
+          .listen((List<DisplayNameModel> event) {
+            // DisplayNameModel does not have userName, only displayName
+            // Therefore use id to set userName of guardian
+            _api.user.get(event.first.id).listen((GirafUserModel event) {
+              _userNameOfGuardian = event.username;  
+            }).onError((Object error) {
+              completer.completeError(error);
+            });
+        }).onError((Object error) {
+          completer.completeError(error);
+        });
+        break;
+      case Role.Guardian:
+        _userNameOfGuardian = _authBloc.loggedInUser.username;
+        break;
+      default:
+        break;
+    }
+
+    completer.complete();
+    Future.wait(<Future<void>>[completer.future]);
+    return completer.future;
   }
 
   IconButton _createIconCopy(VoidCallback callback) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -27,7 +27,7 @@ void main() {
    * Use the "environments.local.json" for running against your local web-api
    * For IOS users: change the SERVER_HOST in the environment.local file to "http://localhost:5000"
    */
-  environment.setFile('assets/environments.local.json').whenComplete(() {
+  environment.setFile('assets/environments.dev.json').whenComplete(() {
     _runApp();
   });
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,7 @@
 import 'package:api_client/api/api.dart';
+import 'package:api_client/models/displayname_model.dart';
+import 'package:api_client/models/enums/role_enum.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:weekplanner/blocs/auth_bloc.dart';
 import 'package:weekplanner/bootstrap.dart';
@@ -7,9 +10,11 @@ import 'package:weekplanner/screens/login_screen.dart';
 import 'package:weekplanner/providers/environment_provider.dart' as environment;
 import 'package:weekplanner/routes.dart';
 import 'package:weekplanner/screens/choose_citizen_screen.dart';
+import 'package:weekplanner/screens/weekplan_selector_screen.dart';
 import 'package:weekplanner/widgets/giraf_notify_dialog.dart';
 
 final Api _api = di.getDependency<Api>();
+final AuthBloc _authBloc = di.getDependency<AuthBloc>();
 
 
 void main() {
@@ -60,8 +65,17 @@ void _runApp() {
             }
             firstTimeLogIn = false;
             if (snapshot.data) {
-              // In case logged in show ChooseCitizenScreen
-              return ChooseCitizenScreen();
+              // Show screen dependent on logged in role
+              switch (_authBloc.loggedInUser.role) {
+                case Role.Citizen:
+                  return WeekplanSelectorScreen(
+                      DisplayNameModel(
+                          displayName: _authBloc.loggedInUser.displayName,
+                          role: describeEnum(_authBloc.loggedInUser.role),
+                          id: _authBloc.loggedInUser.id));
+                default:
+                  return ChooseCitizenScreen();
+              }
             } else {
               // Not loggedIn pop context to login screen.
               Routes.goHome(context);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -27,7 +27,7 @@ void main() {
    * Use the "environments.local.json" for running against your local web-api
    * For IOS users: change the SERVER_HOST in the environment.local file to "http://localhost:5000"
    */
-  environment.setFile('assets/environments.dev.json').whenComplete(() {
+  environment.setFile('assets/environments.local.json').whenComplete(() {
     _runApp();
   });
 }

--- a/lib/screens/choose_citizen_screen.dart
+++ b/lib/screens/choose_citizen_screen.dart
@@ -102,60 +102,62 @@ class _ChooseCitizenScreenState extends State<ChooseCitizenScreen> {
         )).toList();
 
     /// Defines variables needed to check user role
-    final Role role = _authBloc.loggedInUser.role;
+    final Role role = _authBloc.loggedInUser?.role;
 
-    /// Checks user role and gives option to add Citizen if user is Guardian
-    if (role == Role.Guardian) {
-      list.insert(0, FlatButton(
-        onPressed: () async {
-          final Object result =
-          await Routes.push(context, NewCitizenScreen());
-          final DisplayNameModel newUser =
-          DisplayNameModel.fromGirafUser(result);
-          list.add(CitizenAvatar(
-              displaynameModel: newUser,
-              onPressed: () => _pushWeekplanSelector(newUser)
-          )
-          );
+    if (role != null) {
+      /// Checks user role and gives option to add Citizen if user is Guardian
+      if (role == Role.Guardian) {
+        list.insert(0, FlatButton(
+          onPressed: () async {
+            final Object result =
+            await Routes.push(context, NewCitizenScreen());
+            final DisplayNameModel newUser =
+            DisplayNameModel.fromGirafUser(result);
+            list.add(CitizenAvatar(
+                displaynameModel: newUser,
+                onPressed: () => _pushWeekplanSelector(newUser)
+            )
+            );
 
-          ///Update the screen with the new citizen
-          _bloc.updateBloc();
-          setState(() {});
-        },
-        child: Padding(
-          padding: const EdgeInsets.only(bottom: 30),
-          child: Column(
-            children: <Widget>[
-              Expanded(
-                child: LayoutBuilder(builder:
-                    (BuildContext context, BoxConstraints constraints) {
-                  return Icon(
-                    Icons.person_add,
-                    size: constraints.biggest.height,
-                  );
-                }),
-              ),
+            ///Update the screen with the new citizen
+            _bloc.updateBloc();
+            setState(() {});
+          },
+          child: Padding(
+            padding: const EdgeInsets.only(bottom: 30),
+            child: Column(
+              children: <Widget>[
+                Expanded(
+                  child: LayoutBuilder(builder:
+                      (BuildContext context, BoxConstraints constraints) {
+                    return Icon(
+                      Icons.person_add,
+                      size: constraints.biggest.height,
+                    );
+                  }),
+                ),
 
-              ConstrainedBox(
-                  constraints: const BoxConstraints(
-                    minWidth: 200.0,
-                    maxWidth: 200.0,
-                    minHeight: 15.0,
-                    maxHeight: 50.0,
-                  ),
-                  child: const Center(
-                    child: AutoSizeText(
-                        'Tilføj Bruger',
-                        style: TextStyle(fontSize: GirafFont.large,
-                            color: Colors.black)
+                ConstrainedBox(
+                    constraints: const BoxConstraints(
+                      minWidth: 200.0,
+                      maxWidth: 200.0,
+                      minHeight: 15.0,
+                      maxHeight: 50.0,
                     ),
-                  )
-              )
-            ],
+                    child: const Center(
+                      child: AutoSizeText(
+                          'Tilføj Bruger',
+                          style: TextStyle(fontSize: GirafFont.large,
+                              color: Colors.black)
+                      ),
+                    )
+                )
+              ],
+            ),
           ),
-        ),
-      )
-      );
+        )
+        );
+      }
     }
 
 

--- a/lib/screens/choose_citizen_screen.dart
+++ b/lib/screens/choose_citizen_screen.dart
@@ -102,10 +102,10 @@ class _ChooseCitizenScreenState extends State<ChooseCitizenScreen> {
         )).toList();
 
     /// Defines variables needed to check user role
-    final int role = _authBloc.loggedInRole;
+    final Role role = _authBloc.loggedInUser.role;
 
     /// Checks user role and gives option to add Citizen if user is Guardian
-    if (role == Role.Guardian.index) {
+    if (role == Role.Guardian) {
       list.insert(0, FlatButton(
         onPressed: () async {
           final Object result =

--- a/lib/screens/choose_citizen_screen.dart
+++ b/lib/screens/choose_citizen_screen.dart
@@ -11,6 +11,7 @@ import 'package:weekplanner/models/enums/app_bar_icons_enum.dart';
 import 'package:weekplanner/routes.dart';
 import 'package:weekplanner/screens/new_citizen_screen.dart';
 import 'package:weekplanner/screens/weekplan_selector_screen.dart';
+import 'package:weekplanner/style/custom_color.dart';
 import 'package:weekplanner/widgets/citizen_avatar_widget.dart';
 import 'package:weekplanner/widgets/giraf_app_bar_widget.dart';
 import 'package:weekplanner/style/font_size.dart';
@@ -107,7 +108,7 @@ class _ChooseCitizenScreenState extends State<ChooseCitizenScreen> {
     if (role != null) {
       /// Checks user role and gives option to add Citizen if user is Guardian
       if (role == Role.Guardian) {
-        list.insert(0, FlatButton(
+        list.insert(0, TextButton(
           onPressed: () async {
             final Object result =
             await Routes.push(context, NewCitizenScreen());
@@ -133,6 +134,7 @@ class _ChooseCitizenScreenState extends State<ChooseCitizenScreen> {
                     return Icon(
                       Icons.person_add,
                       size: constraints.biggest.height,
+                      color: GirafColors.black,
                     );
                   }),
                 ),
@@ -148,7 +150,7 @@ class _ChooseCitizenScreenState extends State<ChooseCitizenScreen> {
                       child: AutoSizeText(
                           'Tilføj Bruger',
                           style: TextStyle(fontSize: GirafFont.large,
-                              color: Colors.black)
+                              color: GirafColors.black)
                       ),
                     )
                 )

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -199,10 +199,13 @@ class LoginScreenState extends State<LoginScreen> {
                       child: Container(
                         child: Transform.scale(
                           scale: 1.5,
-                          child: RaisedButton(
+                          child: ElevatedButton(
                             key: const Key('LoginBtnKey'),
-                            shape: RoundedRectangleBorder(
+                            style: ElevatedButton.styleFrom(
+                              primary: theme.GirafColors.loginButtonColor,
+                              shape: RoundedRectangleBorder(
                                 borderRadius: BorderRadius.circular(10.0)),
+                            ),
                             child: const Text(
                               'Login',
                               style: TextStyle(color: theme.GirafColors.white),
@@ -210,7 +213,6 @@ class LoginScreenState extends State<LoginScreen> {
                             onPressed: () {
                               loginAction(context);
                             },
-                            color: theme.GirafColors.loginButtonColor,
                           ),
                         ),
                       ),
@@ -220,9 +222,12 @@ class LoginScreenState extends State<LoginScreen> {
                         ? Container(
                             child: Transform.scale(
                               scale: 1.2,
-                              child: RaisedButton(
-                                shape: RoundedRectangleBorder(
+                              child: ElevatedButton(
+                                style: ElevatedButton.styleFrom(
+                                  primary: theme.GirafColors.loginButtonColor,
+                                  shape: RoundedRectangleBorder(
                                     borderRadius: BorderRadius.circular(10.0)),
+                                ),
                                 child: const Text(
                                   'Auto-Login',
                                   key: Key('AutoLoginKey'),
@@ -236,7 +241,6 @@ class LoginScreenState extends State<LoginScreen> {
                                       environment.getVar<String>('PASSWORD');
                                   loginAction(context);
                                 },
-                                color: theme.GirafColors.loginButtonColor,
                               ),
                             ),
                           )

--- a/lib/screens/show_activity_screen.dart
+++ b/lib/screens/show_activity_screen.dart
@@ -365,11 +365,13 @@ class ShowActivityScreen extends StatelessWidget {
                 ),
               ),
             ),
-            RaisedButton(
+            ElevatedButton(
               key: const Key('ChoiceBoardNameButton'),
-              color: theme.GirafColors.gradientDefaultOrange,
-              disabledColor: theme.GirafColors.gradientDisabledOrange,
-              padding: const EdgeInsets.all(8.0),
+              style:  ElevatedButton.styleFrom(
+                primary: theme.GirafColors.gradientDefaultOrange,
+                onSurface: theme.GirafColors.gradientDisabledOrange,
+                padding: const EdgeInsets.all(8.0),
+              ),
               onPressed: () {
                 _activity.choiceBoardName = inputtext;
                 _activityBloc.update();

--- a/lib/screens/take_picture_with_camera_screen.dart
+++ b/lib/screens/take_picture_with_camera_screen.dart
@@ -106,7 +106,7 @@ class TakePictureWithCamera extends StatelessWidget {
     return Padding(
         padding: const EdgeInsets.only(bottom: 15),
         child: Container(
-          child: FlatButton(
+          child: TextButton(
             onPressed: _takePictureWithCamera.takePictureWithCamera,
             child: StreamBuilder<File>(
                 stream: _takePictureWithCamera.file,

--- a/lib/screens/upload_image_from_phone_screen.dart
+++ b/lib/screens/upload_image_from_phone_screen.dart
@@ -101,7 +101,7 @@ class UploadImageFromPhone extends StatelessWidget {
     return Padding(
         padding: const EdgeInsets.only(bottom: 15),
         child: Container(
-          child: FlatButton(
+          child: TextButton(
             onPressed: _uploadFromGallery.chooseImageFromGallery,
             child: StreamBuilder<File>(
                 stream: _uploadFromGallery.file,

--- a/lib/widgets/weekplan_screen_widgets/weekplan_day_column.dart
+++ b/lib/widgets/weekplan_screen_widgets/weekplan_day_column.dart
@@ -490,10 +490,12 @@ class WeekplanDayColumn extends StatelessWidget {
                     AsyncSnapshot<WeekplanMode> snapshot) {
                   return Visibility(
                     visible: snapshot.data == WeekplanMode.guardian,
-                    child: RaisedButton(
+                    child: ElevatedButton(
                         key: const Key('AddActivityButton'),
                         child: Image.asset('assets/icons/add.png'),
-                        color: theme.GirafColors.buttonColor,
+                        style: ElevatedButton.styleFrom(
+                          primary: theme.GirafColors.buttonColor,
+                        ),
                         onPressed: () async {
                           Routes.push(context, PictogramSearch(user: user,))
                               .then((Object object) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -20,7 +20,7 @@ packages:
     description:
       path: "."
       ref: develop
-      resolved-ref: "1d3c1bfdd1cc6d31945e4e665dd637f95fb92cec"
+      resolved-ref: "32d3ca64a7c2ca376dd9ab95ec45b7c652436e25"
       url: "https://github.com/aau-giraf/api_client.git"
     source: git
     version: "0.0.1"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,6 +2,7 @@ name: weekplanner
 description: WeekPlanner for GIRAF
 
 version: 1.2.2+2
+publish_to: 'none'
 
 environment:
   sdk: ">=2.1.0 <3.0.0"

--- a/test/blocs/toolbar_bloc_test.dart
+++ b/test/blocs/toolbar_bloc_test.dart
@@ -14,6 +14,7 @@ void main() {
   setUp(() {
     di.clearAll();
     api = Api('any');
+    di.registerDependency<Api>((_) => api);
     di.registerDependency<AuthBloc>((_) => AuthBloc(api));
     bloc = ToolbarBloc();
     di.registerDependency<ToolbarBloc>((_) => bloc);

--- a/test/screens/choose_citizen_screen_test.dart
+++ b/test/screens/choose_citizen_screen_test.dart
@@ -93,9 +93,9 @@ void main() {
     await tester.pumpWidget(MaterialApp(home: ChooseCitizenScreen()));
     await tester.pumpAndSettle();
     if(role == Role.Guardian) {
-      expect(find.byType(FlatButton), findsNWidgets(1));
+      expect(find.byType(TextButton), findsNWidgets(1));
     } else {
-      expect(find.byType(FlatButton), findsNWidgets(0));
+      expect(find.byType(TextButton), findsNWidgets(0));
     }
   });
 }

--- a/test/screens/choose_citizen_screen_test.dart
+++ b/test/screens/choose_citizen_screen_test.dart
@@ -89,7 +89,7 @@ void main() {
   });
 
   testWidgets('Has add citizen button', (WidgetTester tester) async {
-    final Role role = authBloc.loggedInUser.role;
+    final Role role = authBloc.loggedInUser?.role;
     await tester.pumpWidget(MaterialApp(home: ChooseCitizenScreen()));
     await tester.pumpAndSettle();
     if(role == Role.Guardian) {
@@ -99,6 +99,3 @@ void main() {
     }
   });
 }
-
-
-

--- a/test/screens/choose_citizen_screen_test.dart
+++ b/test/screens/choose_citizen_screen_test.dart
@@ -47,6 +47,7 @@ void main() {
     authBloc = AuthBloc(api);
     api.user = MockUserApi();
     bloc = ChooseCitizenBloc(api);
+    di.registerDependency<Api>((_) => api);
     di.registerDependency<AuthBloc>((_) => AuthBloc(api));
     toolbarBloc = ToolbarBloc();
     di.registerDependency<ChooseCitizenBloc>((_) => bloc);
@@ -88,10 +89,10 @@ void main() {
   });
 
   testWidgets('Has add citizen button', (WidgetTester tester) async {
-    final int role = authBloc.loggedInRole;
+    final Role role = authBloc.loggedInUser.role;
     await tester.pumpWidget(MaterialApp(home: ChooseCitizenScreen()));
     await tester.pumpAndSettle();
-    if(role == Role.Guardian.index) {
+    if(role == Role.Guardian) {
       expect(find.byType(FlatButton), findsNWidgets(1));
     } else {
       expect(find.byType(FlatButton), findsNWidgets(0));

--- a/test/screens/copy_resolve_screen_test.dart
+++ b/test/screens/copy_resolve_screen_test.dart
@@ -127,6 +127,7 @@ void main() {
     });
 
     di.clearAll();
+    di.registerDependency<Api>((_) => api);
     di.registerDependency<EditWeekplanBloc>((_) => EditWeekplanBloc(api));
     di.registerDependency<AuthBloc>((_) => AuthBloc(api));
     di.registerDependency<PictogramImageBloc>((_) => PictogramImageBloc(api));

--- a/test/screens/copy_to_citizens_screen_test.dart
+++ b/test/screens/copy_to_citizens_screen_test.dart
@@ -91,6 +91,7 @@ void main() {
   setUp(() {
     di.clearAll();
     api = Api('any');
+    di.registerDependency<Api>((_) => api);
     api.user = MockUserApi();
     api.week = MockWeekApi();
 

--- a/test/screens/edit_weekplan_screen_test.dart
+++ b/test/screens/edit_weekplan_screen_test.dart
@@ -116,6 +116,7 @@ void main() {
 
     di.clearAll();
     di.registerDependency<WeekplansBloc>((_) => mockWeekplanSelector);
+    di.registerDependency<Api>((_) => api);
     di.registerDependency<AuthBloc>((_) => AuthBloc(api));
     di.registerDependency<PictogramBloc>((_) => PictogramBloc(api));
     di.registerDependency<PictogramImageBloc>((_) => PictogramImageBloc(api));

--- a/test/screens/login_screen_test.dart
+++ b/test/screens/login_screen_test.dart
@@ -71,7 +71,6 @@ class MockAuthBloc extends Mock implements AuthBloc {
   final rx_dart.BehaviorSubject<bool> _loggedIn = rx_dart.BehaviorSubject<bool>
       .seeded(false);
 
-  @override
   String loggedInUsername;
 
   @override

--- a/test/screens/new_citizen_screen_test.dart
+++ b/test/screens/new_citizen_screen_test.dart
@@ -141,6 +141,7 @@ void main() {
     mockNewCitizenBloc = MockNewCitizenBloc(api);
 
     di.clearAll();
+    di.registerDependency<Api>((_) => api);
     di.registerDependency<AuthBloc>((_) => AuthBloc(api));
     di.registerDependency<ToolbarBloc>((_) => ToolbarBloc());
     di.registerDependency<NewCitizenBloc>((_) => mockNewCitizenBloc);

--- a/test/screens/new_weekplan_screen_test.dart
+++ b/test/screens/new_weekplan_screen_test.dart
@@ -116,6 +116,7 @@ void main() {
 
     di.clearAll();
     di.registerDependency<WeekplansBloc>((_) => mockWeekplanSelector);
+    di.registerDependency<Api>((_) => api);
     di.registerDependency<AuthBloc>((_) => AuthBloc(api));
     di.registerDependency<PictogramBloc>((_) => PictogramBloc(api));
     di.registerDependency<PictogramImageBloc>((_) => PictogramImageBloc(api));

--- a/test/screens/pictogram_search_screen_test.dart
+++ b/test/screens/pictogram_search_screen_test.dart
@@ -51,6 +51,7 @@ void main() {
 
     di.clearAll();
     di.registerDependency<PictogramBloc>((_) => bloc);
+    di.registerDependency<Api>((_) => api);
     di.registerDependency<AuthBloc>((_) => AuthBloc(api));
     di.registerDependency<PictogramImageBloc>((_) => PictogramImageBloc(api));
     di.registerDependency<ToolbarBloc>((_) => ToolbarBloc());

--- a/test/screens/settings_screens/color_theme_selection_screen_test.dart
+++ b/test/screens/settings_screens/color_theme_selection_screen_test.dart
@@ -85,6 +85,7 @@ void main() {
     });
 
     di.clearAll();
+    di.registerDependency<Api>((_) => api);
     di.registerDependency<AuthBloc>((_) => AuthBloc(api));
     di.registerDependency<ToolbarBloc>((_) => ToolbarBloc());
     di.registerDependency<SettingsBloc>((_) => settingsBloc);

--- a/test/screens/settings_screens/completed_activity_icon_selection_screen_test.dart
+++ b/test/screens/settings_screens/completed_activity_icon_selection_screen_test.dart
@@ -53,6 +53,7 @@ void main() {
     settingsBloc = SettingsBloc(api);
     settingsBloc.loadSettings(user);
 
+    di.registerDependency<Api>((_) => api);
     di.registerDependency<AuthBloc>((_) => AuthBloc(api));
     di.registerDependency<ToolbarBloc>((_) => ToolbarBloc());
     di.registerDependency<SettingsBloc>((_) => settingsBloc);

--- a/test/screens/settings_screens/privacy_information_screen_test.dart
+++ b/test/screens/settings_screens/privacy_information_screen_test.dart
@@ -52,6 +52,7 @@ void main() {
     });
 
     di.clearAll();
+    di.registerDependency<Api>((_) => api);
     di.registerDependency<AuthBloc>((_) => AuthBloc(api));
     di.registerDependency<ToolbarBloc>((_) => ToolbarBloc());
     di.registerDependency<SettingsBloc>((_) => settingsBloc);

--- a/test/screens/settings_screens/settings_screen_test.dart
+++ b/test/screens/settings_screens/settings_screen_test.dart
@@ -84,6 +84,7 @@ void main() {
       showPopup: false,
     );
 
+    di.registerDependency<Api>((_) => api);
     di.registerDependency<AuthBloc>((_) => AuthBloc(api));
     di.registerDependency<ToolbarBloc>((_) => ToolbarBloc());
     settingsBloc = SettingsBloc(api);

--- a/test/screens/settings_screens/time_representation_screen_test.dart
+++ b/test/screens/settings_screens/time_representation_screen_test.dart
@@ -51,6 +51,7 @@ void main() {
     api.user = MockUserApi();
     mockObserver = MockUserApi();
 
+    di.registerDependency<Api>((_) => api);
     di.registerDependency<AuthBloc>((_) => AuthBloc(api));
     di.registerDependency<ToolbarBloc>((_) => ToolbarBloc());
     di.registerDependency<SettingsBloc>((_) => SettingsBloc(api));

--- a/test/screens/show_activity_screen_test.dart
+++ b/test/screens/show_activity_screen_test.dart
@@ -322,6 +322,7 @@ void main() {
     di.clearAll();
     di.registerDependency<ActivityBloc>((_) => bloc);
     di.registerDependency<AuthBloc>((_) => authBloc);
+    di.registerDependency<Api>((_) => api);
     di.registerDependency<PictogramImageBloc>((_) => PictogramImageBloc(api));
     di.registerDependency<ToolbarBloc>((_) => ToolbarBloc());
     di.registerDependency<TimerBloc>((_) => timerBloc);

--- a/test/screens/show_activity_screen_test.dart
+++ b/test/screens/show_activity_screen_test.dart
@@ -62,7 +62,6 @@ class MockAuth extends Mock implements AuthBloc {
   final rx_dart.BehaviorSubject<WeekplanMode> _mode =
       rx_dart.BehaviorSubject<WeekplanMode>.seeded(WeekplanMode.guardian);
 
-  @override
   String loggedInUsername = 'Graatand';
 
   @override

--- a/test/screens/take_picture_with_camera_screen_test.dart
+++ b/test/screens/take_picture_with_camera_screen_test.dart
@@ -56,6 +56,7 @@ void main() {
     di.clearAll();
     di.registerDependency<TakePictureWithCameraBloc>((_) => bloc);
     di.registerDependency<ToolbarBloc>((_) => ToolbarBloc());
+    di.registerDependency<Api>((_) => api);
     di.registerDependency<AuthBloc>((_) => AuthBloc(api));
   });
 

--- a/test/screens/upload_image_from_phone_screen_test.dart
+++ b/test/screens/upload_image_from_phone_screen_test.dart
@@ -63,6 +63,7 @@ void main() {
     di.clearAll();
     di.registerDependency<UploadFromGalleryBloc>((_) => bloc);
     di.registerDependency<ToolbarBloc>((_) => ToolbarBloc());
+    di.registerDependency<Api>((_) => api);
     di.registerDependency<AuthBloc>((_) => AuthBloc(api));
   });
 

--- a/test/screens/weekplan_screen_test.dart
+++ b/test/screens/weekplan_screen_test.dart
@@ -755,9 +755,9 @@ api.pictogram=MockPictogramApi();
     await tester.pumpWidget(MaterialApp(home: WeekplanScreen(mockWeek, user)));
     await tester.pumpAndSettle();
 
-    expect(find.byType(RaisedButton), findsNWidgets(7));
+    expect(find.byType(ElevatedButton), findsNWidgets(7));
 
-    await tester.tap(find.byType(RaisedButton).first);
+    await tester.tap(find.byType(ElevatedButton).first);
     await tester.pumpAndSettle();
 
     expect(find.byType(PictogramSearch), findsOneWidget);

--- a/test/screens/weekplan_screen_test.dart
+++ b/test/screens/weekplan_screen_test.dart
@@ -69,6 +69,7 @@ api.pictogram=MockPictogramApi();
     // We register the dependencies needed to build different widgets
     di.registerDependency<AuthBloc>((_) => authBloc);
     di.registerDependency<WeekplanBloc>((_) => weekplanBloc);
+    di.registerDependency<Api>((_) => api);
     di.registerDependency<SettingsBloc>((_) => SettingsBloc(api));
     di.registerDependency<ToolbarBloc>((_) => ToolbarBloc());
     di.registerDependency<PictogramImageBloc>((_) => PictogramImageBloc(api));

--- a/test/screens/weekplan_selector_screen_test.dart
+++ b/test/screens/weekplan_selector_screen_test.dart
@@ -220,6 +220,7 @@ void main() {
     di.clearAll();
     di.registerDependency<WeekplansBloc>((_) => bloc);
     di.registerDependency<EditWeekplanBloc>((_) => editBloc);
+    di.registerDependency<Api>((_) => api);
     di.registerDependency<AuthBloc>((_) => AuthBloc(api));
     di.registerDependency<PictogramImageBloc>((_) => PictogramImageBloc(api));
     di.registerDependency<ToolbarBloc>((_) => ToolbarBloc());

--- a/test/widgets/giraf_app_bar_widget_test.dart
+++ b/test/widgets/giraf_app_bar_widget_test.dart
@@ -21,7 +21,6 @@ class MockAuth extends Mock implements AuthBloc {
   final rx_dart.BehaviorSubject<bool> _loggedIn = rx_dart.BehaviorSubject<bool>
       .seeded(true);
 
-  @override
   String loggedInUsername = 'Graatand';
 
 

--- a/test/widgets/giraf_app_bar_widget_test.dart
+++ b/test/widgets/giraf_app_bar_widget_test.dart
@@ -80,6 +80,7 @@ void main() {
 
   setUp(() {
     di.clearAll();
+    di.registerDependency<Api>((_) => api);
     authBloc = MockAuth();
     di.registerDependency<AuthBloc>((_) => authBloc);
     bloc = ToolbarBloc();

--- a/test/widgets/loading_spinner_widget_test.dart
+++ b/test/widgets/loading_spinner_widget_test.dart
@@ -10,16 +10,16 @@ class MockScreen extends StatelessWidget {
       body: Container(
           child: Column(
         children: <Widget>[
-          RaisedButton(
+          ElevatedButton(
               key: const Key('FirstButton'),
               onPressed: () {
                 loadingSpinner(context);
-              }),
-          RaisedButton(
+              }, child: null,),
+          ElevatedButton(
               key: const Key('SecondButton'),
               onPressed: () {
                 Routes.pop(context);
-              }),
+              }, child: null,),
         ],
       )),
     );


### PR DESCRIPTION
# Description

When a citizen is logged in; the week plan selection screen for that citizen will be displayed.
When any other user is logged in; the choose citizen screen will be displayed.

To solve this issue, `AuthBloc` stores the logged-in user data in a `GirafUserModel` object. Hence, the `loggedInUser` object in `auth_bloc.dart` is used to provide logged-in user data in `weekplan_selector_screen.dart` and `choose_citizen_screen.dart`.

Fixes #888 

## Type of change
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tests has been updated to support this new feature.

**Development Configuration**

* Flutter version: 2.0.5
* Dart version: 2.12.3

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas, if necessary
- [X] I have made corresponding changes to the documentation, if necessary
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works, if necessary
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [ ] I have Acceptance Tested this on an iOS device
- [X] I have Acceptance Tested this on an Android device
