### PR TITLE
Feature/826

### DIFF
--- a/lib/blocs/choose_citizen_bloc.dart
+++ b/lib/blocs/choose_citizen_bloc.dart
@@ -21,6 +21,12 @@ class ChooseCitizenBloc extends BlocBase {
       return _api.user.getCitizens(user.id);
     }).listen((List<DisplayNameModel> citizens) {
       _citizens.add(citizens);
+    }).onError((Object error){
+      if(error.toString() == "[ApiException]: UserHasNoCitizens") {
+        return null; // Do not return any citizens if the web-api throws UserHasNoCitzens. See issue #826 on GitHub for more info.
+      } else {
+        return Future<void>.error(error); // Return the error if it is not a UserHasNoCitzens error.
+      }
     });
   }
 

--- a/lib/blocs/choose_citizen_bloc.dart
+++ b/lib/blocs/choose_citizen_bloc.dart
@@ -21,19 +21,22 @@ class ChooseCitizenBloc extends BlocBase {
       return _api.user.getCitizens(user.id);
     }).listen((List<DisplayNameModel> citizens) {
       _citizens.add(citizens);
-    }).onError((Object error){
-      if(error.toString() == "[ApiException]: UserHasNoCitizens") {
-        return null; // Do not return any citizens if the web-api throws UserHasNoCitzens. See issue #826 on GitHub for more info.
+    }).onError((Object error) {
+      if (error.toString() == '[ApiException]: UserHasNoCitizens') {
+        // Do not return any citizens if the web-api throws UserHasNoCitzens.
+        // See issue #826 on GitHub for more info.
+        return null;
       } else {
-        return Future<void>.error(error); // Return the error if it is not a UserHasNoCitzens error.
+        // Return the error if it is not a UserHasNoCitzens error.
+        return Future<void>.error(error);
       }
     });
   }
 
   final Api _api;
   final rx_dart.BehaviorSubject<List<DisplayNameModel>> _citizens =
-  rx_dart.BehaviorSubject<List<DisplayNameModel>>.seeded(
-      <DisplayNameModel>[]);
+      rx_dart.BehaviorSubject<List<DisplayNameModel>>.seeded(
+          <DisplayNameModel>[]);
 
   @override
   void dispose() {


### PR DESCRIPTION
Added error handling for unproblematic error from the web-api. Guardians should not see a list of citizens if they don't have any assigned. The web-api, however, raises an exception if this is the case. This is an unproblematic error in the scenario of a guardian choosing citizen after login, if they aren't assigned to any citizens at that moment. If no citizens are assigned, the screen should show no citizens and no error should be shown.

# Description

Fixes #\<issue_no>

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration*

**Development Configuration**
*Type "flutter --version" and "dart --version" in your CMD to check versions.*

* Flutter version: 3.3.9
* Dart version: 2.18.5

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas, if necessary
- [ ] I have made corresponding changes to the documentation, if necessary
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works, if necessary
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have Acceptance Tested this on an iOS device
- [x] I have Acceptance Tested this on an Android device
