### PR TITLE
Edit code

### DIFF
--- a/assets/environments.dev.json
+++ b/assets/environments.dev.json
@@ -1,5 +1,5 @@
 {
-  "SERVER_HOST": "https://srv.giraf.cs.aau.dk/DEV/API",
+  "SERVER_HOST": "http://localhost:5000/",
   "DEBUG": true,
   "USERNAME": "Guardian-dev",
   "PASSWORD": "password2"

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -26,7 +26,7 @@ void main() {
    * Use the "environments.local.json" for running against your local web-api
    * For IOS users: change the SERVER_HOST in the environment.local file to "http://localhost:5000"
    */
-  environment.setFile('assets/environments.dev.json').whenComplete(() {
+  environment.setFile('assets/environments.local.json').whenComplete(() {
     _runApp();
   });
 }
@@ -42,7 +42,7 @@ void _runApp() {
   runApp(MaterialApp(
       title: 'Weekplanner',
       theme: ThemeData(fontFamily: 'Quicksand'),
-      //debugShowCheckedModeBanner: false,
+      debugShowCheckedModeBanner: false,
       home: StreamBuilder<bool>(
           initialData: false,
           stream: di.get<AuthBloc>().loggedIn.where((bool currentState) =>

--- a/lib/screens/new_citizen_screen.dart
+++ b/lib/screens/new_citizen_screen.dart
@@ -15,11 +15,17 @@ import 'package:weekplanner/widgets/giraf_button_widget.dart';
 /// Role names for Weekplanner
 enum Roles {
   /// Guardian role
-  guardian,
+    guardian,
   /// Trustee  role
-  trustee,
-  /// Citizen role
-  citizen }
+    trustee,
+   /// Citizen role
+   citizen }
+
+Map<Roles, String> roleText = {
+  Roles.guardian: 'pædagog',
+  Roles.trustee: 'værge',
+  Roles.citizen: 'borger',
+};
 
 /// Screen for creating a new citizen
 // ignore: must_be_immutable
@@ -120,7 +126,7 @@ class _NewCitizenScreenState extends State<NewCitizenScreen> {
                             Expanded(
                               child: ListTile(
                                 key: const Key('guardianRadioButton'),
-                                title: const Text('Guardian'),
+                                title: const Text('Pædagog'),
                                 leading: Radio<Roles>(
                                   value: Roles.guardian,
                                   groupValue: _role,
@@ -137,7 +143,7 @@ class _NewCitizenScreenState extends State<NewCitizenScreen> {
                             Expanded(
                               child: ListTile(
                                 key: const Key('trusteeRadioButton'),
-                                title: const Text('Trustee'),
+                                title: const Text('Værge'),
                                 leading: Radio<Roles>(
                                   value: Roles.trustee,
                                   groupValue: _role,
@@ -154,7 +160,7 @@ class _NewCitizenScreenState extends State<NewCitizenScreen> {
                             Expanded(
                               child: ListTile(
                                 key: const Key('citizenRadioButton'),
-                                title: const Text('Citizen'),
+                                title: const Text('Borger'),
                                 leading: Radio<Roles>(
                                   value: Roles.citizen,
                                   groupValue: _role,
@@ -280,12 +286,12 @@ class _NewCitizenScreenState extends State<NewCitizenScreen> {
                     );
                   }),
             ),
-            const Padding(
-              padding: EdgeInsets.symmetric(vertical: 10, horizontal: 16),
+            Padding( // edit
+              padding: const EdgeInsets.symmetric(vertical: 10, horizontal: 16),
               //child: Text('Profil billede af borger (valgfri):'),
               child: AutoSizeText(
-                'Profil billede af borger (valgfri):',
-                style: TextStyle(fontSize: GirafFont.small),
+                'Profil billede af ${roleText[_role]} (valgfri):',
+                style: const TextStyle(fontSize: GirafFont.small),
               ),
             ),
       


### PR DESCRIPTION
# Description

Currently when creating new users their titles are in English in the Weekplanner, they should be in Danish. Translate these into Danish.

Guardian = Pædagog
Trustee = Værge
Citizen = Borger

Aditionally "borger" should be replaced with the selected role.

![image](https://github.com/aau-giraf/weekplanner/assets/95319419/fbe079df-b2ba-4036-bed8-8558fdbca260)

Fixes #\<940>

## Type of change
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Possible Suggested Solution

Translate these into English
![image](https://github.com/aau-giraf/weekplanner/assets/95319419/e01e05f1-99dd-4be0-a4b5-7496dd2cbde5)

# How Has This Been Tested?
Android Platform: emulation is carried out using Android Studio on Windows computer
iOS Platform: emulation is carried out using Xcode on MacBook

**Development Configuration**

* Flutter version: 3.3.8
* Dart version: 2.18.4

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas, if necessary
- [ ] I have made corresponding changes to the documentation, if necessary
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works, if necessary
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have Acceptance Tested this on an iOS device
- [x] I have Acceptance Tested this on an Android device
