### PR TITLE
Feature/948

### DIFF
--- a/lib/screens/show_activity_screen.dart
+++ b/lib/screens/show_activity_screen.dart
@@ -710,89 +710,92 @@ class ShowActivityScreen extends StatelessWidget {
   /// of the button depends on whether it is in guardian or citizen mode.
   ButtonBar buildButtonBar() {
     return ButtonBar(
-        // Key used for testing widget.
-        key: const Key('ButtonBarRender'),
-        alignment: MainAxisAlignment.center,
-        children: <Widget>[
-          StreamBuilder<WeekplanMode>(
-            stream: _authBloc.mode,
-            builder: (BuildContext context,
-                AsyncSnapshot<WeekplanMode> weekplanModeSnapshot) {
-              return StreamBuilder<ActivityModel>(
-                  stream: _activityBloc.activityModelStream,
-                  builder: (BuildContext context,
-                      AsyncSnapshot<ActivityModel> activitySnapshot) {
-                    if (activitySnapshot.data == null) {
-                      return const CircularProgressIndicator();
-                    }
+      // Key used for testing widget.
+      key: const Key('ButtonBarRender'),
+      alignment: MainAxisAlignment.center,
+      children: <Widget>[
+        StreamBuilder<WeekplanMode>(
+          stream: _authBloc.mode,
+          builder: (BuildContext context,
+              AsyncSnapshot<WeekplanMode> weekplanModeSnapshot) {
+            return StreamBuilder<ActivityModel>(
+              stream: _activityBloc.activityModelStream,
+              builder: (BuildContext context,
+                  AsyncSnapshot<ActivityModel> activitySnapshot) {
+                if (activitySnapshot.data == null) {
+                  return const CircularProgressIndicator();
+                }
 
-                    final GirafButton completeButton = GirafButton(
-                        key: const Key('CompleteStateToggleButton'),
-                        onPressed: () {
-                          _activityBloc.completeActivity();
+                ActivityState activityState = activitySnapshot.data.state;
+                final bool isComplete = activityState != ActivityState.Canceled;
+                final bool isCanceled =
+                    activityState != ActivityState.Completed;
 
+                final bool showCancelButton =
+                    weekplanModeSnapshot.data == WeekplanMode.guardian &&
+                        isCanceled;
+                final bool showCompleteButton = isComplete;
 
-                        },
-                        isEnabled: activitySnapshot.data.state !=
-                            ActivityState.Canceled,
-                        text: activitySnapshot.data.state !=
-                                ActivityState.Completed
-                            ? 'Afslut'
-                            : 'Fortryd',
-                        icon: activitySnapshot.data.state !=
-                                ActivityState.Completed
-                            ? const ImageIcon(
-                                AssetImage('assets/icons/accept.png'),
-                                color: theme.GirafColors.green)
-                            : const ImageIcon(
-                                AssetImage('assets/icons/undo.png'),
-                                color: theme.GirafColors.blue));
+                final GirafButton completeButton = GirafButton(
+                  key: const Key('CompleteStateToggleButton'),
+                  onPressed: showCompleteButton
+                      ? () {
+                    _activityBloc.completeActivity();
+                    activityState = _activityBloc.getActivity().state;
+                  }
+                      : null,
+                  text: isCanceled ? 'Afslut' : 'Fortryd',
+                  icon: isCanceled
+                      ? const ImageIcon(
+                    AssetImage('assets/icons/accept.png'),
+                    color: theme.GirafColors.green,
+                  )
+                      : const ImageIcon(
+                    AssetImage('assets/icons/undo.png'),
+                    color: theme.GirafColors.blue,
+                  ),
+                );
 
-                    if (weekplanModeSnapshot.data == WeekplanMode.guardian) {
-                      final GirafButton cancelButton = GirafButton(
-                        key: const Key('CancelStateToggleButton'),
-                        onPressed: () {
-                          _activityBloc.cancelActivity();
-         _activity.state = _activityBloc.getActivity().state;
-                          //This removes current context
-                          // so back button correctly navigates
+                final GirafButton cancelButton = GirafButton(
+                  key: const Key('CancelStateToggleButton'),
+                  onPressed: showCancelButton
+                      ? () {
+                    _activityBloc.cancelActivity();
+                    activityState = _activityBloc.getActivity().state;
+                  }
+                      : null,
+                  text: isComplete ? 'Aflys' : 'Fortryd',
+                  icon: isComplete
+                      ? const ImageIcon(
+                    AssetImage('assets/icons/cancel.png'),
+                    color: theme.GirafColors.red,
+                  )
+                      : const ImageIcon(
+                    AssetImage('assets/icons/undo.png'),
+                    color: theme.GirafColors.blue,
+                  ),
+                );
 
-                        },
-                        isEnabled: activitySnapshot.data.state !=
-                            ActivityState.Completed,
-                        text: activitySnapshot.data.state !=
-                                ActivityState.Canceled
-                            ? 'Aflys'
-                            : 'Fortryd',
-                        icon: activitySnapshot.data.state !=
-                                ActivityState.Canceled
-                            ? const ImageIcon(
-                                AssetImage('assets/icons/cancel.png'),
-                                color: theme.GirafColors.red)
-                            : const ImageIcon(
-                                AssetImage('assets/icons/undo.png'),
-                                color: theme.GirafColors.blue),
-                      );
-
-                      if (_activity.isChoiceBoard) {
-                        return Container(
-                            child: Row(children: <Widget>[cancelButton]));
-                      } else {
-                        return Container(
-                            child: Row(children: <Widget>[
-                          Padding(
-                              padding: const EdgeInsets.only(right: 40.0),
-                              child: completeButton),
-                          cancelButton
-                        ]));
-                      }
-                    } else {
-                      return completeButton;
-                    }
-                  });
-            },
-          ),
-        ]);
+                return Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: <Widget>[
+                    Visibility(
+                      visible: showCompleteButton,
+                      child: completeButton,
+                    ),
+                    const SizedBox(width: 15),
+                    Visibility(
+                      visible: showCancelButton,
+                      child: cancelButton,
+                    ),
+                  ],
+                );
+              },
+            );
+          },
+        ),
+      ],
+    );
   }
 
   /// Builds the input field and buttons for changing the description of


### PR DESCRIPTION
# Description

When the user selects a specific activity in the 'Ugeplan' user interface, it leads them to the 'Aktivitet' user interface, where there are two buttons: 'Afslut' and 'Aflys' (Figure a). If the user presses 'Afslut,' the 'Aflys' button becomes disabled (Figure b). Conversely, if the user presses 'Aflys,' the 'Afslut' button will be disabled (Figure c). 
![image](https://github.com/aau-giraf/weekplanner/assets/95319419/837bb9aa-6be2-4407-8bce-6b449e1245ff)

The problem is that the buttons' states aren't updated immediately. The Users have to reload the 'Aktivitet' user interface to see the changes take effect. For example, when the user selects the 'Afslut' button, the 'Aflys' button's state doesn't change right away (Figure d). To observe the correct state as shown in Figure e, the user needs to return to the 'Ugeplan' screen and then select the activity again. After reloading the 'Aktivitet' UI, if the user presses 'Fortryd' (as in Figure e), the 'Aflys' button still displays the incorrect state (Figure f) instead of the expected state (Figure g).
![image](https://github.com/aau-giraf/weekplanner/assets/95319419/3adf3b31-2149-4c12-9089-fafe90f54491)

Fixes #\<948>
Possible suggested solution:
When one button is pressed, the other gray button becomes hidden, and if the user presses 'Fortryd,' both buttons reappear in their normal state (as shown in the figure below). This eliminates the need to reload the 'Aktivitet' user interface every time, ensuring that both buttons are always in a usable state.
![image](https://github.com/aau-giraf/weekplanner/assets/95319419/ae004566-dd2d-4c7e-8b44-33e742d6a51c)

## Type of change
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Android Platform: emulation is carried out using Android Studio on Windows computer
iOS Platform: emulation is carried out using Xcode on MacBook

**Development Configuration**

* Flutter version: 3.3.8
* Dart version: 2.18.4

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas, if necessary
- [ ] I have made corresponding changes to the documentation, if necessary
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works, if necessary
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have Acceptance Tested this on an iOS device
- [x] I have Acceptance Tested this on an Android device
