### PR TITLE
Fixed issue with completed weeks (#702)

### DIFF
--- a/lib/blocs/weekplan_selector_bloc.dart
+++ b/lib/blocs/weekplan_selector_bloc.dart
@@ -231,10 +231,11 @@ class WeekplansBloc extends BlocBase {
     final int currentWeekNum = currentWeek[0];
     final int currentYear = currentWeek[1];
 
-    // Checks how many weeks there are in the current year.
-    // If it's a leap year or a thursday on January 1, there are 53 weeks
+    // Checks how many weeks there were/are in the year where the weekplan
+    // was created. If it's a leap year or a Thursday on January 1,
+    // there are/were 53 weeks
     int amountOfWeeksInYear = 52;
-    if (DateTime(currentYear, 1, 1).day == DateTime.thursday ||
+    if (DateTime(currentYear - 1, 1, 1).day == DateTime.thursday ||
         currentYear % 4 == 0) {
       amountOfWeeksInYear = 53;
     }

--- a/lib/blocs/weekplan_selector_bloc.dart
+++ b/lib/blocs/weekplan_selector_bloc.dart
@@ -29,10 +29,10 @@ class WeekplansBloc extends BlocBase {
   Stream<List<WeekModel>> get markedWeekModels => _markedWeekModels.stream;
 
   final rx_dart.BehaviorSubject<List<WeekModel>> _weekModel =
-    rx_dart.BehaviorSubject<List<WeekModel>>();
+      rx_dart.BehaviorSubject<List<WeekModel>>();
 
   final rx_dart.BehaviorSubject<List<WeekModel>> _oldWeekModel =
-    rx_dart.BehaviorSubject<List<WeekModel>>();
+      rx_dart.BehaviorSubject<List<WeekModel>>();
 
   /// This is a stream where all the old [WeekModel] are put in,
   /// and this is the stream to listen to,
@@ -40,13 +40,13 @@ class WeekplansBloc extends BlocBase {
   Stream<List<WeekModel>> get oldWeekModels => _oldWeekModel.stream;
 
   final rx_dart.BehaviorSubject<List<WeekNameModel>> _weekNameModelsList =
-    rx_dart.BehaviorSubject<List<WeekNameModel>>();
+      rx_dart.BehaviorSubject<List<WeekNameModel>>();
 
   final rx_dart.BehaviorSubject<bool> _editMode =
-    rx_dart.BehaviorSubject<bool>.seeded(false);
+      rx_dart.BehaviorSubject<bool>.seeded(false);
 
   final rx_dart.BehaviorSubject<List<WeekModel>> _markedWeekModels =
-    rx_dart.BehaviorSubject<List<WeekModel>>.seeded(<WeekModel>[]);
+      rx_dart.BehaviorSubject<List<WeekModel>>.seeded(<WeekModel>[]);
 
   final Api _api;
   DisplayNameModel _user;
@@ -91,10 +91,10 @@ class WeekplansBloc extends BlocBase {
     getWeekDetails(weekPlanNames, weekDetails, oldWeekDetails);
 
     final Stream<List<WeekModel>> getWeekPlans =
-      reformatWeekDetailsToObservableList(weekDetails);
+        reformatWeekDetailsToObservableList(weekDetails);
 
     final Stream<List<WeekModel>> getOldWeekPlans =
-      reformatWeekDetailsToObservableList(oldWeekDetails);
+        reformatWeekDetailsToObservableList(oldWeekDetails);
 
     getWeekPlans
         .take(1)
@@ -114,13 +114,13 @@ class WeekplansBloc extends BlocBase {
       List<Stream<WeekModel>> details) {
     // ignore: always_specify_types
     return details.isEmpty
-    // Ignore type specification; Stream<WeekModel>
-    //   does not contain .empty()
-    // ignore: always_specify_types
+        // Ignore type specification; Stream<WeekModel>
+        //   does not contain .empty()
+        // ignore: always_specify_types
         ? const Stream.empty()
         : details.length == 1
-        ? details[0].map((WeekModel plan) => <WeekModel>[plan])
-        : rx_dart.Rx.combineLatestList(details);
+            ? details[0].map((WeekModel plan) => <WeekModel>[plan])
+            : rx_dart.Rx.combineLatestList(details);
   }
 
   /// Makes API calls to get the weekplan details
@@ -144,9 +144,10 @@ class WeekplansBloc extends BlocBase {
     }
   }
 
-  /// Returns the current week number
-  int getCurrentWeekNum() {
-    return getWeekNumberFromDate(DateTime.now());
+  /// Returns the current week number and its year
+  List<int> getCurrentWeekNum() {
+    final DateTime now = DateTime.now();
+    return [getWeekNumberFromDate(now), now.year];
   }
 
   /// Calculates the current week number from a given date
@@ -226,12 +227,30 @@ class WeekplansBloc extends BlocBase {
 
   /// Checks if a week is in the past/expired
   bool isWeekDone(WeekNameModel weekPlan) {
-    final int currentYear = DateTime.now().year;
-    final int currentWeek = getCurrentWeekNum();
+    final List<int> currentWeek = getCurrentWeekNum();
+    final int currentWeekNum = currentWeek[0];
+    final int currentYear = currentWeek[1];
+
+    // Checks how many weeks there are in the current year.
+    // If it's a leap year or a thursday on January 1, there are 53 weeks
+    int amountOfWeeksInYear = 52;
+    if (DateTime(currentYear, 1, 1).day == DateTime.thursday ||
+        currentYear % 4 == 0) {
+      amountOfWeeksInYear = 53;
+    }
+
+    // Checks if the weekplan is from last year's last week and checks if there
+    // is an overlap over the new year
+    if (weekPlan.weekYear == currentYear - 1 &&
+        currentWeekNum == 1 &&
+        weekPlan.weekNumber == amountOfWeeksInYear &&
+        DateTime.now().day != 1) {
+      return false;
+    }
 
     if (weekPlan.weekYear < currentYear ||
         (weekPlan.weekYear == currentYear &&
-            weekPlan.weekNumber < currentWeek)) {
+            weekPlan.weekNumber < currentWeekNum)) {
       return true;
     }
     return false;
@@ -264,10 +283,10 @@ class WeekplansBloc extends BlocBase {
 
   /// Delete the marked week models when the trash button is clicked
   void deleteMarkedWeekModels() {
-    final List<WeekModel> localWeekModels = _weekModel.hasValue ?
-    _weekModel.value : null;
-    final List<WeekModel> oldLocalWeekModels = _oldWeekModel.hasValue ?
-    _oldWeekModel.value.toList() : null;
+    final List<WeekModel> localWeekModels =
+        _weekModel.hasValue ? _weekModel.value : null;
+    final List<WeekModel> oldLocalWeekModels =
+        _oldWeekModel.hasValue ? _oldWeekModel.value.toList() : null;
     // Updates the weekplan in the database
     for (WeekModel weekModel in _markedWeekModels.value) {
       _api.week
@@ -291,10 +310,10 @@ class WeekplansBloc extends BlocBase {
   /// This method deletes the given week model from the database after checking
   /// if it's an old weekplan or an upcoming
   void deleteWeekModel(WeekModel weekModel) {
-    final List<WeekModel> localWeekModels = _weekModel.hasValue ?
-    _weekModel.value : null;
-    final List<WeekModel> oldLocalWeekModels = _oldWeekModel.hasValue ?
-    _oldWeekModel.value : null;
+    final List<WeekModel> localWeekModels =
+        _weekModel.hasValue ? _weekModel.value : null;
+    final List<WeekModel> oldLocalWeekModels =
+        _oldWeekModel.hasValue ? _oldWeekModel.value : null;
 
     if (localWeekModels != null && localWeekModels.contains(weekModel)) {
       deleteWeek(localWeekModels, weekModel);
@@ -343,7 +362,7 @@ class WeekplansBloc extends BlocBase {
   /// Returns a WeekModel list of the marked weeks
   Future<List<WeekModel>> getMarkedWeeks() async {
     final List<WeekModel> weekList = <WeekModel>[];
-    for (WeekModel weekModel in _markedWeekModels.value){
+    for (WeekModel weekModel in _markedWeekModels.value) {
       final Completer<WeekModel> completer = Completer<WeekModel>();
       _api.week
           .get(_user.id, weekModel.weekYear, weekModel.weekNumber)

--- a/test/blocs/weekplans_bloc_test.dart
+++ b/test/blocs/weekplans_bloc_test.dart
@@ -21,17 +21,17 @@ void main() {
 
   final List<WeekNameModel> weekNameModelList = <WeekNameModel>[];
   final WeekNameModel weekNameModel1 =
-  WeekNameModel(name: 'name', weekNumber: 8, weekYear: 2020);
+      WeekNameModel(name: 'name', weekNumber: 8, weekYear: 2020);
   final WeekNameModel weekNameModel2 =
-  WeekNameModel(name: 'name', weekNumber: 3, weekYear: 2021);
+      WeekNameModel(name: 'name', weekNumber: 3, weekYear: 2021);
   final WeekNameModel weekNameModel3 =
-  WeekNameModel(name: 'name', weekNumber: 28, weekYear: 2020);
+      WeekNameModel(name: 'name', weekNumber: 28, weekYear: 2020);
   final WeekNameModel weekNameModel4 =
-  WeekNameModel(name: 'name', weekNumber: 3, weekYear: 2020);
+      WeekNameModel(name: 'name', weekNumber: 3, weekYear: 2020);
   final WeekNameModel weekNameModel5 =
-  WeekNameModel(name: 'name', weekNumber: 50, weekYear: 2019);
+      WeekNameModel(name: 'name', weekNumber: 50, weekYear: 2019);
   final WeekNameModel weekNameModel6 =
-  WeekNameModel(name: 'name', weekNumber: 8, weekYear: 9999);
+      WeekNameModel(name: 'name', weekNumber: 8, weekYear: 9999);
   final List<WeekModel> weekModelList = <WeekModel>[];
   final WeekModel weekModel1 = WeekModel(weekNumber: 8, weekYear: 2020);
   final WeekModel weekModel2 = WeekModel(weekNumber: 3, weekYear: 2021);
@@ -40,7 +40,7 @@ void main() {
   final WeekModel weekModel5 = WeekModel(weekNumber: 50, weekYear: 2019);
   final WeekModel weekModel6 = WeekModel(weekNumber: 8, weekYear: 9999);
   final DisplayNameModel mockUser =
-  DisplayNameModel(displayName: 'test', id: 'test', role: 'test');
+      DisplayNameModel(displayName: 'test', id: 'test', role: 'test');
 
   void setupApiCalls() {
     weekNameModelList.clear();
@@ -49,39 +49,38 @@ void main() {
     weekModelList.add(weekModel1);
     weekNameModelList.add(weekNameModel1);
 
-    when(weekApi.getNames('test')).thenAnswer(
-            (_) => rx_dart.BehaviorSubject<List<WeekNameModel>>
-                .seeded(weekNameModelList));
+    when(weekApi.getNames('test')).thenAnswer((_) =>
+        rx_dart.BehaviorSubject<List<WeekNameModel>>.seeded(weekNameModelList));
 
-    when(weekApi
-        .get('test', weekNameModel1.weekYear, weekNameModel1.weekNumber))
-        .thenAnswer((_) => rx_dart.BehaviorSubject<WeekModel>
-        .seeded(weekModel1));
+    when(weekApi.get(
+            'test', weekNameModel1.weekYear, weekNameModel1.weekNumber))
+        .thenAnswer(
+            (_) => rx_dart.BehaviorSubject<WeekModel>.seeded(weekModel1));
 
-    when(weekApi
-        .get('test', weekNameModel2.weekYear, weekNameModel2.weekNumber))
-        .thenAnswer((_) => rx_dart.BehaviorSubject<WeekModel>
-        .seeded(weekModel2));
+    when(weekApi.get(
+            'test', weekNameModel2.weekYear, weekNameModel2.weekNumber))
+        .thenAnswer(
+            (_) => rx_dart.BehaviorSubject<WeekModel>.seeded(weekModel2));
 
-    when(weekApi
-        .get('test', weekNameModel3.weekYear, weekNameModel3.weekNumber))
-        .thenAnswer((_) => rx_dart.BehaviorSubject<WeekModel>
-        .seeded(weekModel3));
+    when(weekApi.get(
+            'test', weekNameModel3.weekYear, weekNameModel3.weekNumber))
+        .thenAnswer(
+            (_) => rx_dart.BehaviorSubject<WeekModel>.seeded(weekModel3));
 
-    when(weekApi
-        .get('test', weekNameModel4.weekYear, weekNameModel4.weekNumber))
-        .thenAnswer((_) => rx_dart.BehaviorSubject<WeekModel>
-        .seeded(weekModel4));
+    when(weekApi.get(
+            'test', weekNameModel4.weekYear, weekNameModel4.weekNumber))
+        .thenAnswer(
+            (_) => rx_dart.BehaviorSubject<WeekModel>.seeded(weekModel4));
 
-    when(weekApi
-        .get('test', weekNameModel5.weekYear, weekNameModel5.weekNumber))
-        .thenAnswer((_) => rx_dart.BehaviorSubject<WeekModel>
-        .seeded(weekModel5));
+    when(weekApi.get(
+            'test', weekNameModel5.weekYear, weekNameModel5.weekNumber))
+        .thenAnswer(
+            (_) => rx_dart.BehaviorSubject<WeekModel>.seeded(weekModel5));
 
-    when(weekApi
-        .get('test', weekNameModel6.weekYear, weekNameModel6.weekNumber))
-        .thenAnswer((_) => rx_dart.BehaviorSubject<WeekModel>
-        .seeded(weekModel6));
+    when(weekApi.get(
+            'test', weekNameModel6.weekYear, weekNameModel6.weekNumber))
+        .thenAnswer(
+            (_) => rx_dart.BehaviorSubject<WeekModel>.seeded(weekModel6));
 
     when(weekApi.delete(mockUser.id, any, any))
         .thenAnswer((_) => rx_dart.BehaviorSubject<bool>.seeded(true));
@@ -135,20 +134,20 @@ void main() {
 
   test('Removes a weekmodel from the list of marked weekmodels',
       async((DoneFn done) {
-        // Add the weekmodel to list of marked weekmodels
-        bloc.toggleMarkedWeekModel(weekModel1);
-        expect(bloc.getNumberOfMarkedWeekModels(), 1);
+    // Add the weekmodel to list of marked weekmodels
+    bloc.toggleMarkedWeekModel(weekModel1);
+    expect(bloc.getNumberOfMarkedWeekModels(), 1);
 
-        bloc.markedWeekModels
-            .skip(1)
-            .listen((List<WeekModel> markedWeekModelsList) {
-          expect(markedWeekModelsList.length, 0);
-          done();
-        });
+    bloc.markedWeekModels
+        .skip(1)
+        .listen((List<WeekModel> markedWeekModelsList) {
+      expect(markedWeekModelsList.length, 0);
+      done();
+    });
 
-        // Remove the weekmodel from the list of marked weekmodels.
-        bloc.toggleMarkedWeekModel(weekModel1);
-      }));
+    // Remove the weekmodel from the list of marked weekmodels.
+    bloc.toggleMarkedWeekModel(weekModel1);
+  }));
 
   test('Clear the list of marked weekmodels', async((DoneFn done) {
     // Add the weekmodel to list of marked weekmodels
@@ -187,49 +186,48 @@ void main() {
 
   test('Checks if the number of marked weekmodels matches',
       async((DoneFn done) {
-        bloc.toggleMarkedWeekModel(weekModel1);
-        expect(bloc.getNumberOfMarkedWeekModels(), 1);
+    bloc.toggleMarkedWeekModel(weekModel1);
+    expect(bloc.getNumberOfMarkedWeekModels(), 1);
 
-        bloc.toggleMarkedWeekModel(WeekModel(name: 'testWeekModel'));
-        expect(bloc.getNumberOfMarkedWeekModels(), 2);
+    bloc.toggleMarkedWeekModel(WeekModel(name: 'testWeekModel'));
+    expect(bloc.getNumberOfMarkedWeekModels(), 2);
 
-        bloc.toggleMarkedWeekModel(weekModel1);
-        expect(bloc.getNumberOfMarkedWeekModels(), 1);
-        done();
-      }));
+    bloc.toggleMarkedWeekModel(weekModel1);
+    expect(bloc.getNumberOfMarkedWeekModels(), 1);
+    done();
+  }));
 
   test('Checks if the marked weekmodels are deleted from the weekmodels',
       async((DoneFn done) {
-        final List<WeekNameModel> weekNameModelList = <WeekNameModel>[
-          weekNameModel1
-        ];
-        when(weekApi.get(
+    final List<WeekNameModel> weekNameModelList = <WeekNameModel>[
+      weekNameModel1
+    ];
+    when(weekApi.get(
             mockUser.id, weekNameModel1.weekYear, weekNameModel1.weekNumber))
-            .thenAnswer((_) => rx_dart.BehaviorSubject<WeekModel>
-            .seeded(weekModel1));
+        .thenAnswer(
+            (_) => rx_dart.BehaviorSubject<WeekModel>.seeded(weekModel1));
 
-        when(weekApi.getNames(mockUser.id)).thenAnswer(
-                (_) => rx_dart.BehaviorSubject<List<WeekNameModel>>
-                    .seeded(weekNameModelList));
+    when(weekApi.getNames(mockUser.id)).thenAnswer((_) =>
+        rx_dart.BehaviorSubject<List<WeekNameModel>>.seeded(weekNameModelList));
 
-        bloc.load(mockUser);
-        bloc.toggleMarkedWeekModel(weekModel1);
-        expect(bloc.getNumberOfMarkedWeekModels(), 1);
+    bloc.load(mockUser);
+    bloc.toggleMarkedWeekModel(weekModel1);
+    expect(bloc.getNumberOfMarkedWeekModels(), 1);
 
-        int count = 0;
-        bloc.weekModels.listen((List<WeekModel> userWeekModels) {
-          if (count == 0) {
-            bloc.deleteMarkedWeekModels();
-            count++;
-          } else {
-            expect(userWeekModels.contains(weekModel1), false);
-            expect(userWeekModels.length, 0);
-            expect(bloc.getNumberOfMarkedWeekModels(), 0);
-          }
-        });
+    int count = 0;
+    bloc.weekModels.listen((List<WeekModel> userWeekModels) {
+      if (count == 0) {
+        bloc.deleteMarkedWeekModels();
+        count++;
+      } else {
+        expect(userWeekModels.contains(weekModel1), false);
+        expect(userWeekModels.length, 0);
+        expect(bloc.getNumberOfMarkedWeekModels(), 0);
+      }
+    });
 
-        done();
-      }));
+    done();
+  }));
 
   test('check deletion of new weekplan without oldWeekPlan',
       async((DoneFn done) {
@@ -237,13 +235,12 @@ void main() {
       weekNameModel6
     ];
     when(weekApi.get(
-        mockUser.id, weekNameModel6.weekYear, weekNameModel6.weekNumber))
-        .thenAnswer((_) => rx_dart.BehaviorSubject<WeekModel>
-        .seeded(weekModel6));
+            mockUser.id, weekNameModel6.weekYear, weekNameModel6.weekNumber))
+        .thenAnswer(
+            (_) => rx_dart.BehaviorSubject<WeekModel>.seeded(weekModel6));
 
-    when(weekApi.getNames(mockUser.id)).thenAnswer(
-            (_) => rx_dart.BehaviorSubject<List<WeekNameModel>>
-            .seeded(weekNameModelList));
+    when(weekApi.getNames(mockUser.id)).thenAnswer((_) =>
+        rx_dart.BehaviorSubject<List<WeekNameModel>>.seeded(weekNameModelList));
 
     bloc.load(mockUser);
     bloc.toggleMarkedWeekModel(weekModel6);
@@ -310,7 +307,9 @@ void main() {
 
   test('Test marked week models', async((DoneFn done) {
     final List<WeekModel> correctMarked = <WeekModel>[
-      weekModel1, weekModel2, weekModel3
+      weekModel1,
+      weekModel2,
+      weekModel3
     ];
 
     bloc.toggleMarkedWeekModel(weekModel1);
@@ -329,7 +328,6 @@ void main() {
   The test is skipped for now (Remove skip from the end of the test)
    */
     test('Check if the correct week number is returned', async((DoneFn done) {
-
       /* Semi-random checks */
       expect(bloc.getWeekNumberFromDate(DateTime(2020, 10, 14)), 42);
       expect(bloc.getWeekNumberFromDate(DateTime(2020, 10, 7)), 41);
@@ -347,7 +345,6 @@ void main() {
       expect(bloc.getWeekNumberFromDate(DateTime(2022, 3, 28)), 13);
       expect(bloc.getWeekNumberFromDate(DateTime(2022, 10, 30)), 43);
       expect(bloc.getWeekNumberFromDate(DateTime(2022, 10, 31)), 44);
-
 
       /* These next expects checks the same week in years where the
      first of January starts on different week days.
@@ -431,12 +428,11 @@ void main() {
       expect(bloc.getWeekNumberFromDate(DateTime(2023, 3, 20)), 12);
 
       done();
-    })/*, skip: 'Only needed if the function breaks'*/);
+    }) /*, skip: 'Only needed if the function breaks'*/);
 
-
-    test('Check if the correct week number is returned '
+    test(
+        'Check if the correct week number is returned '
         'from list of dates', async((DoneFn done) {
-
       // Because GitHub CI is stupid
       File file = File('${Directory.current.path}/blocs/'
           'Dates_with_weeks_2020_to_2030_semi.csv');
@@ -449,13 +445,14 @@ void main() {
       final String csv = file.readAsStringSync();
 
       const CsvToListConverter converter = CsvToListConverter(
-          fieldDelimiter: ',', textDelimiter: '"',
-          textEndDelimiter: '"', eol: ';');
+          fieldDelimiter: ',',
+          textDelimiter: '"',
+          textEndDelimiter: '"',
+          eol: ';');
 
       final List<List<dynamic>> datesAndWeeks = converter.convert<dynamic>(csv);
 
       for (int i = 0; i < datesAndWeeks.length; i++) {
-
         final DateTime date = DateTime.parse(datesAndWeeks[i][0]);
         final int expectedWeek = datesAndWeeks[i][1];
 
@@ -463,8 +460,7 @@ void main() {
 
         try {
           expect(actualWeek, expectedWeek);
-        }
-        on TestFailure {
+        } on TestFailure {
           print('Error in calculating week number for date: '
               '${date.toString()}\nGot $actualWeek, '
               'expected $expectedWeek');
@@ -474,9 +470,59 @@ void main() {
 
       done();
     }));
+
+    test(
+        'Check if the given weekplan is completed '
+        'from list of dates', async((DoneFn done) {
+      // Because GitHub CI is stupid
+      File file = File('${Directory.current.path}/blocs/'
+          'Dates_with_weeks_2020_to_2030_semi.csv');
+
+      if (!file.existsSync()) {
+        file = File('${Directory.current.path}/test/blocs/'
+            'Dates_with_weeks_2020_to_2030_semi.csv');
+      }
+
+      final String csv = file.readAsStringSync();
+
+      const CsvToListConverter converter = CsvToListConverter(
+          fieldDelimiter: ',',
+          textDelimiter: '"',
+          textEndDelimiter: '"',
+          eol: ';');
+
+      final List<List<dynamic>> datesAndWeeks = converter.convert<dynamic>(csv);
+
+      // Get the current week number and year
+      final List<int> currentWeekNumAndYear = bloc.getCurrentWeekNum();
+
+      final int currentWeekNum = currentWeekNumAndYear[0];
+      final int currentYear = currentWeekNumAndYear[1];
+
+      print('Test was ran on: ${DateTime.now().toString()}');
+      for (int i = 0; i < datesAndWeeks.length; i++) {
+        final DateTime date = DateTime.parse(datesAndWeeks[i][0]);
+        final int week = datesAndWeeks[i][1];
+        final int year = date.year;
+
+        final bool expectedCompleted = year < currentYear ||
+            (year == currentYear && week < currentWeekNum);
+
+        final bool actualCompleted =
+            bloc.isWeekDone(WeekNameModel(weekNumber: week, weekYear: year));
+
+        try {
+          expect(actualCompleted, expectedCompleted);
+        } on TestFailure {
+          print('Error in validating isWeekDone for date: '
+              '${date.day.toString()}/${date.month.toString()}/${date.year.toString()}\nGot $actualCompleted, '
+              'expected $expectedCompleted');
+          fail('');
+        }
+      }
+      done();
+    }));
   });
-
-
 
   // test('Weekplans should be split into old and upcoming',
   // async((DoneFn done){
@@ -511,5 +557,4 @@ void main() {
   //
   //  done();
   // }));
-
 }


### PR DESCRIPTION
# Description

Fixed bug where a current week plan would be added to "Overståede uger" if the week crosses into the new year. The issue occurred when a week's number is the same on both sides of the New Year, for example a week starting on the 29th of December and ending on the 4th of January the following year. The issue was fixed by adding more checks for cases where the error might occur.

Fixes #702

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

The code has been tested independently of any mobile platform, where the tests were ran using Visual Studio Code

* Flutter version: 3.3.8
* Dart version: 2.18.4

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas, if necessary
- [x] I have made corresponding changes to the documentation, if necessary
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have Acceptance Tested this on an iOS device
- [ ] I have Acceptance Tested this on an Android device
