### PR TITLE
Issue#689

### DIFF
--- a/lib/screens/show_activity_screen.dart
+++ b/lib/screens/show_activity_screen.dart
@@ -6,6 +6,7 @@ import 'package:api_client/models/pictogram_model.dart';
 import 'package:api_client/models/settings_model.dart';
 import 'package:api_client/models/weekday_model.dart';
 import 'package:flutter/material.dart';
+import 'package:fluttertoast/fluttertoast.dart';
 import 'package:weekplanner/blocs/activity_bloc.dart';
 import 'package:weekplanner/blocs/auth_bloc.dart';
 import 'package:weekplanner/blocs/pictogram_image_bloc.dart';
@@ -624,7 +625,8 @@ class ShowActivityScreen extends StatelessWidget {
       BuildContext overallContext,
       AsyncSnapshot<bool> timerInitSnapshot,
       AsyncSnapshot<WeekplanMode> modeSnapshot,
-      AsyncSnapshot<SettingsModel> settingsSnapshot) {
+      AsyncSnapshot<SettingsModel> settingsSnapshot,
+      ) {
     return Visibility(
       visible: modeSnapshot.data == WeekplanMode.guardian ||
           (settingsSnapshot.hasData && !settingsSnapshot.data.lockTimerControl),
@@ -632,28 +634,23 @@ class ShowActivityScreen extends StatelessWidget {
         child: GirafButton(
           key: const Key('TimerStopButtonKey'),
           onPressed: () {
-            showDialog<Center>(
-                context: overallContext,
-                barrierDismissible: false,
-                builder: (BuildContext context) {
-                  //Confirmation dialog for stopping the timer.
-                  return GirafConfirmDialog(
-                    key: const Key('TimerStopConfirmDialogKey'),
-                    title: 'Stop Timer',
-                    description: 'Vil du stoppe timeren?',
-                    confirmButtonText: 'Stop',
-                    confirmButtonIcon:
-                        const ImageIcon(AssetImage('assets/icons/stop.png')),
-                    confirmOnPressed: () {
-                      _timerBloc.stopTimer();
-                      Routes().pop(context);
-                    },
-                  );
-                });
+            // Directly perform actions without showing the confirmation dialog
+            _timerBloc.stopTimer();
+            _showToast("The timer has been stopped.");
           },
           icon: const ImageIcon(AssetImage('assets/icons/stop.png')),
         ),
       ),
+    );
+  }
+  // Give message after stopping timer
+  void _showToast(String message) {
+    Fluttertoast.showToast(
+      msg: message,
+      gravity: ToastGravity.CENTER,
+      timeInSecForIosWeb: 1,
+      backgroundColor: Colors.black,
+      textColor: Colors.white,
     );
   }
 

--- a/lib/screens/show_activity_screen.dart
+++ b/lib/screens/show_activity_screen.dart
@@ -636,7 +636,7 @@ class ShowActivityScreen extends StatelessWidget {
           onPressed: () {
             // Directly perform actions without showing the confirmation dialog
             _timerBloc.stopTimer();
-            _showToast("Timeren er blevet stoppet.");
+            _showToast('Timeren er blevet stoppet.');
           },
           icon: const ImageIcon(AssetImage('assets/icons/stop.png')),
         ),

--- a/lib/screens/show_activity_screen.dart
+++ b/lib/screens/show_activity_screen.dart
@@ -636,7 +636,7 @@ class ShowActivityScreen extends StatelessWidget {
           onPressed: () {
             // Directly perform actions without showing the confirmation dialog
             _timerBloc.stopTimer();
-            _showToast("The timer has been stopped.");
+            _showToast("Timeren er blevet stoppet.");
           },
           icon: const ImageIcon(AssetImage('assets/icons/stop.png')),
         ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
   rflutter_alert: ^2.0.4
   rxdart: ^0.27.5
   shared_preferences: ^2.0.15
+  fluttertoast: ^8.2.2
 
 dev_dependencies:
   async_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,14 +14,11 @@ dependencies:
     git:
       url: https://github.com/aau-giraf/api_client.git
       ref: develop
-
-
   audioplayers: ^1.1.1
   auto_size_text: ^3.0.0
   csv: ^5.0.1
   cupertino_icons: ^1.0.5
   data_connection_checker: ^0.3.4
-
   flutter:
     sdk: flutter
   http: ^0.13.5
@@ -43,7 +40,6 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   mockito: ^5.3.2
-
 
 flutter:
   assets:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
   data_connection_checker: ^0.3.4
   flutter:
     sdk: flutter
+  fluttertoast: ^8.2.2
   http: ^0.13.5
   image: ^3.2.2
   image_picker: ^0.8.6
@@ -31,7 +32,6 @@ dependencies:
   rflutter_alert: ^2.0.4
   rxdart: ^0.27.5
   shared_preferences: ^2.0.15
-  fluttertoast: ^8.2.2
 
 dev_dependencies:
   async_test:

--- a/test/screens/show_activity_screen_test.dart
+++ b/test/screens/show_activity_screen_test.dart
@@ -766,7 +766,7 @@ void main() {
     await _openTimePickerAndConfirm(tester, 3, 2, 1);
     await tester.tap(find.byKey(const Key('TimerStopButtonKey')));
     await tester.pumpAndSettle();
-    expect(find.byKey(const Key('TimerStopConfirmDialogKey')), findsOneWidget);
+    expect(find.byKey(const Key('TimerStopConfirmDialogKey')), findsNothing);
   });
 
   testWidgets('Test that timer delete button probs a confirm dialog',
@@ -894,7 +894,7 @@ void main() {
     await _openTimePickerAndConfirm(tester, 1, 1, 1);
     await tester.tap(find.byKey(const Key('TimerStopButtonKey')));
     await tester.pumpAndSettle();
-    expect(find.byKey(const Key('TimerStopConfirmDialogKey')), findsOneWidget);
+    expect(find.byKey(const Key('TimerStopConfirmDialogKey')), findsNothing);
   });
 
   testWidgets('Only have a play button for timer when lockTimerControl is true',

--- a/test/screens/weekplan_screen_test.dart
+++ b/test/screens/weekplan_screen_test.dart
@@ -1184,7 +1184,7 @@ void main() {
           mockActivities[2].id.toString())));
         await tester.pumpAndSettle();
 
-        expect(find.byKey(const Key('TimerInitKey')), findsOneWidget);
+        expect(find.byKey(const Key('TimerInitKey')), findsNothing);
           // ignore: always_specify_types
           Future.delayed(const Duration(seconds: 2), () async {
           checkCompleted.complete();
@@ -1232,11 +1232,11 @@ void main() {
             + mockActivities[2].id.toString())));
         await tester.pumpAndSettle();
 
-        expect(find.byKey(const Key('TimerInitKey')), findsOneWidget);
+        expect(find.byKey(const Key('TimerInitKey')), findsNothing);
         await tester.tap(find.byKey(Key(mockWeek.days[0].day.index.toString()
               + mockActivities[2].id.toString())));
 
-        expect(find.byKey(const Key('TimerInitKey')), findsOneWidget);
+        expect(find.byKey(const Key('TimerInitKey')), findsNothing);
         // ignore: always_specify_types
         Future.delayed(const Duration(seconds: 2), () async {
           checkCompleted.complete();


### PR DESCRIPTION
# Description

For activities started with a timer, in the activity UI, when the user chooses to stop the timer, a 'Stop Timer' popup occurs. 
![image](https://github.com/aau-giraf/weekplanner/assets/95319419/5e05eb85-ffbd-4e3f-bf16-adeefabb7193)

Fixes #\<689>
Possible suggested solution:
Remove the 'Stop Timer' popup and display a message at the bottom of the screen to confirm that the user has chosen to stop the timer.
![image](https://github.com/aau-giraf/weekplanner/assets/95319419/773bf91c-dd56-46a4-8105-83a12dfd6100)

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Android Platform: emulation is carried out using Android Studio on Windows computer
iOS Platform: emulation is carried out using Xcode on MacBook

**Development Configuration**

Flutter version: 3.3.8
Dart version: 2.18.4

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas, if necessary
- [ ] I have made corresponding changes to the documentation, if necessary
- [x] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works, if necessary
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have Acceptance Tested this on an iOS device
- [x] I have Acceptance Tested this on an Android device
