### PR TITLE
new update 942

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -47,7 +47,7 @@ ext.getKeystorePassword = {
 }
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'

--- a/lib/screens/new_citizen_screen.dart
+++ b/lib/screens/new_citizen_screen.dart
@@ -75,6 +75,11 @@ class _NewCitizenScreenState extends State<NewCitizenScreen> {
     widget._bloc.resetBloc();
   }
 
+  /// Variables to control the enable state of a 'Gem bruger' button and
+  /// 'Videre' button
+  bool isButtonSaveEnabled = true;
+  bool isButtonContinueEnabled = false;
+
   @override
   Widget build(BuildContext context) {
     widget.screenHeight = MediaQuery.of(context).size.height;
@@ -98,10 +103,10 @@ class _NewCitizenScreenState extends State<NewCitizenScreen> {
                       key: const Key('displayNameField'),
                       decoration: InputDecoration(
                         border:
-                            const OutlineInputBorder(borderSide: BorderSide()),
+                        const OutlineInputBorder(borderSide: BorderSide()),
                         labelText: 'Navn',
                         errorText: (snapshot.data == true) &&
-                                widget._bloc.displayNameController.value != null
+                            widget._bloc.displayNameController.value != null
                             ? null
                             : 'Navn skal udfyldes',
                       ),
@@ -185,13 +190,13 @@ class _NewCitizenScreenState extends State<NewCitizenScreen> {
                       key: const Key('usernameField'),
                       decoration: InputDecoration(
                         border:
-                            const OutlineInputBorder(borderSide: BorderSide()),
+                        const OutlineInputBorder(borderSide: BorderSide()),
                         labelText: 'Brugernavn',
                         errorText: (snapshot.data == true) &&
-                                widget._bloc.usernameController.value != null
+                            widget._bloc.usernameController.value != null
                             ? null
-                            // cant make it shorter because of the string
-                            // ignore: lines_longer_than_80_chars
+                        // cant make it shorter because of the string
+                        // ignore: lines_longer_than_80_chars
                             : 'Brugernavn er tomt eller indeholder et ugyldigt tegn',
                       ),
                       onChanged: widget._bloc.onUsernameChange.add,
@@ -204,7 +209,7 @@ class _NewCitizenScreenState extends State<NewCitizenScreen> {
                 const Text('Brug piktogram kode?'),
                 Padding(
                     padding:
-                        const EdgeInsets.symmetric(vertical: 3, horizontal: 10),
+                    const EdgeInsets.symmetric(vertical: 3, horizontal: 10),
                     child: StreamBuilder<Object>(
                         stream: null,
                         builder: (BuildContext context,
@@ -215,12 +220,16 @@ class _NewCitizenScreenState extends State<NewCitizenScreen> {
                                   ._bloc.usePictogramPasswordController.value!,
                               onChanged: _role == Roles.citizen
                                   ? (bool value) {
-                                      setState(() {
-                                        widget
-                                            ._bloc.onUsePictogramPasswordChange
-                                            .add(value);
-                                      });
-                                    }
+                                setState(() {
+                                  // Enable 'Videre' button
+                                  isButtonContinueEnabled = value;
+                                  widget
+                                      ._bloc.onUsePictogramPasswordChange
+                                      .add(value);
+                                  // Hide 'Gem bruger' button
+                                  isButtonSaveEnabled = !value;
+                                });
+                              }
                                   : null);
                         }))
               ],
@@ -233,20 +242,20 @@ class _NewCitizenScreenState extends State<NewCitizenScreen> {
                       (BuildContext context, AsyncSnapshot<bool> snapshot) {
                     return Visibility(
                       visible:
-                          !widget._bloc.usePictogramPasswordController.value!,
+                      !widget._bloc.usePictogramPasswordController.value!,
                       child: TextFormField(
                         key: const Key('passwordField'),
                         enabled:
-                            !widget._bloc.usePictogramPasswordController.value!,
+                        !widget._bloc.usePictogramPasswordController.value!,
                         decoration: InputDecoration(
                           border: const OutlineInputBorder(
                               borderSide: BorderSide()),
                           labelText: 'Kodeord',
                           errorText: (snapshot.data == true) &&
-                                  widget._bloc.passwordController.value != null
+                              widget._bloc.passwordController.value != null
                               ? null
-                              // cant make it shorter because of the string
-                              // ignore: lines_longer_than_80_chars
+                          // cant make it shorter because of the string
+                          // ignore: lines_longer_than_80_chars
                               : 'Kodeord må ikke indeholde mellemrum eller være tom',
                         ),
                         onChanged: widget._bloc.onPasswordChange.add,
@@ -263,11 +272,11 @@ class _NewCitizenScreenState extends State<NewCitizenScreen> {
                       (BuildContext context, AsyncSnapshot<bool> snapshot) {
                     return Visibility(
                       visible:
-                          !widget._bloc.usePictogramPasswordController.value!,
+                      !widget._bloc.usePictogramPasswordController.value!,
                       child: TextFormField(
                         key: const Key('passwordVerifyField'),
                         enabled:
-                            !widget._bloc.usePictogramPasswordController.value!,
+                        !widget._bloc.usePictogramPasswordController.value!,
                         decoration: InputDecoration(
                           border: const OutlineInputBorder(
                               borderSide: BorderSide()),
@@ -311,13 +320,13 @@ class _NewCitizenScreenState extends State<NewCitizenScreen> {
               children: <Widget>[
                 Padding(
                   padding:
-                      const EdgeInsets.symmetric(vertical: 10, horizontal: 16),
+                  const EdgeInsets.symmetric(vertical: 10, horizontal: 16),
 
                   /// Add from gallery button
                   child: GirafButton(
                     key: const Key('TilføjFraGalleriButton'),
                     icon:
-                        const ImageIcon(AssetImage('assets/icons/gallery.png')),
+                    const ImageIcon(AssetImage('assets/icons/gallery.png')),
                     text: 'Tilføj fra galleri',
                     onPressed: widget._bloc.chooseImageFromGallery,
                     child: StreamBuilder<File?>(
@@ -328,7 +337,7 @@ class _NewCitizenScreenState extends State<NewCitizenScreen> {
                               .data; // Store the data in a local variable
                           return fileData != null
                               ? widget._displayImage(
-                                  fileData) // Use the local variable
+                              fileData) // Use the local variable
                               : widget._displayIfNoImage();
                         }),
                   ),
@@ -336,12 +345,14 @@ class _NewCitizenScreenState extends State<NewCitizenScreen> {
               ],
             ),
 
-            Row(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: <Widget>[
-                Padding(
+            // Enable 'Gem bruger' button for new user creation
+            // (Pædagog, Værge, Borger) with regular code
+            Center(
+              child: Visibility(
+                visible: isButtonSaveEnabled,
+                child: Padding(
                   padding:
-                      const EdgeInsets.symmetric(vertical: 10, horizontal: 16),
+                  const EdgeInsets.symmetric(vertical: 10, horizontal: 16),
                   child: GirafButton(
                     key: const Key('saveButton'),
                     icon: const ImageIcon(AssetImage('assets/icons/save.png')),
@@ -358,7 +369,7 @@ class _NewCitizenScreenState extends State<NewCitizenScreen> {
                               previousRoute(response);
                             }
                           }).onError((Object error) =>
-                                  _translator.catchApiError(error, context));
+                              _translator.catchApiError(error, context));
                           break;
                         case Roles.trustee:
                           widget._bloc
@@ -368,7 +379,7 @@ class _NewCitizenScreenState extends State<NewCitizenScreen> {
                               previousRoute(response);
                             }
                           }).onError((Object error) =>
-                                  _translator.catchApiError(error, context));
+                              _translator.catchApiError(error, context));
                           break;
                         case Roles.citizen:
                           widget._bloc
@@ -378,21 +389,27 @@ class _NewCitizenScreenState extends State<NewCitizenScreen> {
                               previousRoute(response);
                             }
                           }).onError((Object error) =>
-                                  _translator.catchApiError(error, context));
+                              _translator.catchApiError(error, context));
                           break;
                       }
                     },
                   ),
                 ),
-                const SizedBox(
-                  width: 30,
-                ),
-                Padding(
-                  padding: const EdgeInsets.symmetric(vertical: 10),
+              ),
+            ),
+
+            // Enable 'Videre' button for new Borger user creation with
+            // pictogram code
+            Center(
+              child: Visibility(
+                visible: isButtonContinueEnabled,
+                child: Padding(
+                  padding:
+                  const EdgeInsets.symmetric(vertical: 10, horizontal: 16),
                   child: GirafButton(
                     key: const Key('nextButton'),
                     icon:
-                        const ImageIcon(AssetImage('assets/icons/accept.png')),
+                    const ImageIcon(AssetImage('assets/icons/accept.png')),
                     text: 'Videre',
                     isEnabled: false,
                     isEnabledStream: widget._bloc.validUsePictogramStream,
@@ -403,16 +420,17 @@ class _NewCitizenScreenState extends State<NewCitizenScreen> {
                           MaterialPageRoute<void>(
                               builder: (BuildContext context) =>
                                   NewPictogramPasswordScreen(
-                                    widget._bloc.usernameController.value!,
-                                    widget._bloc.displayNameController.value!,
-                                    widget._bloc.encodePicture(
-                                            widget._bloc.fileController.value)
-                                        as Uint8List,
-                                  )));
+                                      widget._bloc.usernameController.value!,
+                                      widget._bloc.displayNameController.value!,
+                                      Uint8List.fromList(
+                                        widget._bloc.encodePicture(widget
+                                            ._bloc.fileController.value) ??
+                                            <int>[],
+                                      ))));
                     },
                   ),
                 ),
-              ],
+              ),
             ),
           ],
         ),

--- a/test/blocs/edit_weekplan_bloc_test.dart
+++ b/test/blocs/edit_weekplan_bloc_test.dart
@@ -49,11 +49,14 @@ void main() {
 
     when(() => api.week.getNames(any())).thenAnswer(
       (_) {
-        return Stream<List<WeekNameModel>?>.value(<WeekNameModel>[
-          WeekNameModel(
+        return Stream<List<WeekNameModel>>.fromIterable(<List<WeekNameModel>>[
+          <WeekNameModel>[
+            WeekNameModel(
               name: mockWeek.name,
               weekNumber: mockWeek.weekNumber,
-              weekYear: mockWeek.weekYear),
+              weekYear: mockWeek.weekYear,
+            ),
+          ]
         ]);
       },
     );

--- a/test/blocs/weekplans_bloc_test.dart
+++ b/test/blocs/weekplans_bloc_test.dart
@@ -58,7 +58,7 @@ void main() {
   });
 
   when(() => weekApi.getNames('test')).thenAnswer((_) =>
-      rx_dart.BehaviorSubject<List<WeekNameModel>?>.seeded(weekNameModelList));
+      rx_dart.BehaviorSubject<List<WeekNameModel>>.seeded(weekNameModelList));
 
   when(() => weekApi.get(
           'test', weekNameModel1.weekYear!, weekNameModel1.weekNumber!))


### PR DESCRIPTION
# Description

The 'Videre' button is only used when generating the pictogram code for 'Borger' in the 'Ny bruger' UI. However, when a user adds a new user (pædagog, værge, borger) with regular code, the 'Videre' button still appears, even though it is not used. Similarly, when the user creates the pictogram code, the 'Gem bruger' button becomes redundant. This can be confusing for the user.
![image](https://github.com/aau-giraf/weekplanner/assets/95319419/330206c3-e59a-4a9d-9875-7b25cc660cf4)

Fixes #\<942>
Possible suggested solution:
The 'Videre' button is disabled when the user adds a new user (pædagog, værge, borger) and creates regular code, and it becomes enabled when the user is creating pictogram code for 'Borger'. During this time, the 'Gem bruger' button is also disabled.
![image](https://github.com/aau-giraf/weekplanner/assets/95319419/95dcc438-d8f5-40bc-8d88-34eccd84771f)

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Android Platform: emulation is carried out using Android Studio on Windows computer
iOS Platform: emulation is carried out using Xcode on MacBook

**Development Configuration**
*Type "flutter --version" and "dart --version" in your CMD to check versions.*

Flutter version: 3.16.0
Dart version: 3.2.0

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas, if necessary
- [ ] I have made corresponding changes to the documentation, if necessary
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works, if necessary
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have Acceptance Tested this on an iOS device
- [x] I have Acceptance Tested this on an Android device
