### PR TITLE
Issue#945

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -47,7 +47,7 @@ ext.getKeystorePassword = {
 }
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'

--- a/lib/blocs/activity_bloc.dart
+++ b/lib/blocs/activity_bloc.dart
@@ -89,6 +89,14 @@ class ActivityBloc extends BlocBase {
     update();
   }
 
+  /// Update the Activity after removing from the day
+  void removeActivity() {
+    _activityModel.state = _activityModel.state == ActivityState.Removed
+        ? ActivityState.Normal
+        : ActivityState.Removed;
+    update();
+  }
+
   /// Update the Activity with the new state.
   void update() {
     _api.activity

--- a/lib/models/enums/activity_state_enum.dart
+++ b/lib/models/enums/activity_state_enum.dart
@@ -1,0 +1,2 @@
+///
+enum ActivityState { Normal, Active, Canceled, Completed, Removed }

--- a/lib/screens/show_activity_screen.dart
+++ b/lib/screens/show_activity_screen.dart
@@ -113,11 +113,17 @@ class ShowActivityScreen extends StatelessWidget {
     return Scaffold(
         resizeToAvoidBottomInset: false,
         appBar: GirafAppBar(
+          leading: IconButton(
+            icon: const Icon(Icons.arrow_back),
+            onPressed: () {
+              _weekplanBloc.loadWeek(_girafUser);
+              Routes().pop(context);
+            },
+          ),
           title: 'Aktivitet',
           appBarIcons: (mode == WeekplanMode.guardian)
               ? <AppBarIcon, VoidCallback>{AppBarIcon.changeToCitizen: () {}}
               : <AppBarIcon, VoidCallback>{AppBarIcon.changeToGuardian: () {}},
-          key: UniqueKey(),
         ),
         body: childContainer);
   }
@@ -843,6 +849,8 @@ class ShowActivityScreen extends StatelessWidget {
                             key: const Key('SavePictogramTextForCitizenBtn'),
                             onPressed: () {
                               _activityBloc.setAlternateName(tec.text);
+                              _weekplanBloc.loadWeek(_girafUser);
+                              Routes().pop(context);
                             },
                             text: 'Gem til borger',
                           ),

--- a/lib/widgets/giraf_app_bar_widget.dart
+++ b/lib/widgets/giraf_app_bar_widget.dart
@@ -8,7 +8,7 @@ import 'package:weekplanner/style/custom_color.dart';
 import 'package:weekplanner/widgets/giraf_title_header.dart';
 
 class GirafAppBar extends StatelessWidget implements PreferredSizeWidget {
-  GirafAppBar({Key? key, this.title, this.appBarIcons})
+  GirafAppBar({Key? key, this.title, this.appBarIcons, this.leading,})
       : toolbarBloc = di.get<ToolbarBloc>(),
         preferredSize = const Size.fromHeight(56.0),
         super(key: key);
@@ -19,7 +19,7 @@ class GirafAppBar extends StatelessWidget implements PreferredSizeWidget {
 
   @override
   final Size preferredSize;
-
+  final Widget? leading; // Define a leading widget
   @override
   Widget build(BuildContext context) {
     toolbarBloc.updateIcons(appBarIcons, context);
@@ -31,6 +31,7 @@ class GirafAppBar extends StatelessWidget implements PreferredSizeWidget {
       title: Text(title ?? '',
           overflow: TextOverflow.clip,
           style: const TextStyle(color: GirafColors.black)),
+      leading: leading, // set the leading widget
       flexibleSpace: const GirafTitleHeader(),
       actions: <Widget>[
         StreamBuilder<List<IconButton>>(

--- a/lib/widgets/weekplan_screen_widgets/activity_card.dart
+++ b/lib/widgets/weekplan_screen_widgets/activity_card.dart
@@ -321,6 +321,24 @@ class ActivityCard extends StatelessWidget {
                 }
 
                 return const Center(child: CircularProgressIndicator());
+              case ActivityState.Removed:
+                if (role == WeekplanMode.guardian) {
+                  return Icon(
+                    Icons.check,
+                    key: const Key('IconComplete'),
+                    color: theme.GirafColors.red,
+                    size: MediaQuery.of(context).size.width,
+                  );
+                } else if (role == WeekplanMode.citizen) {
+                  if (settings!.completeMark == null) {
+                    return Container(
+                      width: 0,
+                      height: 0,
+                    );
+                  }
+                }
+
+                return const Center(child: CircularProgressIndicator());
               case ActivityState.Canceled:
                 return Icon(
                   Icons.clear,
@@ -352,7 +370,7 @@ class ActivityCard extends StatelessWidget {
                     height: 0,
                   );
                 }
-                
+
               default:
                 return Container(
                   width: 0,

--- a/lib/widgets/weekplan_screen_widgets/weekplan_day_column.dart
+++ b/lib/widgets/weekplan_screen_widgets/weekplan_day_column.dart
@@ -574,7 +574,8 @@ class WeekplanDayColumn extends StatelessWidget {
           title: 'Slet aktiviteter',
           description: 'Vil du slette ' +
               weekplanBloc.getNumberOfMarkedActivities().toString() +
-              '${weekplanBloc.getNumberOfMarkedActivities() == 1 ? ' aktivitet' : ' aktiviteter'}?',
+              '${weekplanBloc.getNumberOfMarkedActivities() == 1 ?
+              ' aktivitet' : ' aktiviteter'}?',
           confirmButtonText: 'Slet',
           confirmButtonIcon:
               const ImageIcon(AssetImage('assets/icons/delete.png')),

--- a/lib/widgets/weekplan_screen_widgets/weekplan_day_column.dart
+++ b/lib/widgets/weekplan_screen_widgets/weekplan_day_column.dart
@@ -393,6 +393,12 @@ class WeekplanDayColumn extends StatelessWidget {
   // Returning a widget that stacks a pictogram and an status icon
   FittedBox _pictogramIconStack(
       BuildContext context, int index, WeekdayModel weekday, bool inEditMode) {
+    if (weekday.activities == null || weekday.activities!.isEmpty) {
+      return const FittedBox(
+        child: SizedBox.shrink(),
+      );
+    }
+
     final ActivityModel currActivity = weekday.activities![index];
     final bool isMarked = weekplanBloc.isActivityMarked(currActivity);
 
@@ -410,7 +416,8 @@ class WeekplanDayColumn extends StatelessWidget {
                 builder: (BuildContext context,
                     AsyncSnapshot<SettingsModel?> settingsSnapshot) {
                   if (settingsSnapshot.hasData && modeSnapshot.hasData) {
-                    return Draggable<SettingsModel>(
+                    return Draggable<ActivityModel>(
+                      data: currActivity,
                       child: SizedBox(
                         width: 600,
                         height: 600,

--- a/test/blocs/edit_weekplan_bloc_test.dart
+++ b/test/blocs/edit_weekplan_bloc_test.dart
@@ -49,7 +49,7 @@ void main() {
 
     when(() => api.week.getNames(any())).thenAnswer(
       (_) {
-        return Stream<List<WeekNameModel>?>.value(<WeekNameModel>[
+        return Stream<List<WeekNameModel>>.value(<WeekNameModel>[
           WeekNameModel(
               name: mockWeek.name,
               weekNumber: mockWeek.weekNumber,

--- a/test/blocs/weekplans_bloc_test.dart
+++ b/test/blocs/weekplans_bloc_test.dart
@@ -58,7 +58,7 @@ void main() {
   });
 
   when(() => weekApi.getNames('test')).thenAnswer((_) =>
-      rx_dart.BehaviorSubject<List<WeekNameModel>?>.seeded(weekNameModelList));
+      rx_dart.BehaviorSubject<List<WeekNameModel>>.seeded(weekNameModelList));
 
   when(() => weekApi.get(
           'test', weekNameModel1.weekYear!, weekNameModel1.weekNumber!))


### PR DESCRIPTION
# Description

Now, only the guardian can delete activities in the 'Edit mode' UI, while the citizen can only mark activities as finished. The citizen wishes to remove finished activities from the day to focus solely on activities that haven't been completed.

Fixes #\<945>

Possible Suggested Solution:
1. For the guardian:
Activities can be dragged from their current position in the 'ugeplan' UI, dropped, and then deleted from the day. Only one activity can be deleted at a time.
The guardian can drag and delete all activities without any conditions.

https://github.com/aau-giraf/weekplanner/assets/95319419/45e2e3d0-cf0c-44dd-9de3-a60d1154dbfc

2. For the citizen:
Only activities that have been marked as 'complete' or have finished running a timer can be removed.
After marking an activity as finished, long-press on the small box at the bottom right of the activity to remove it from the day.

https://github.com/aau-giraf/weekplanner/assets/95319419/62429d00-9f42-4072-8857-45f9adc34935

The activities that were removed by the citizen will not be deleted; they will only be hidden from the citizen's screen. The guardian can see them with the red 'complete' mark on his screen. 

![image](https://github.com/aau-giraf/weekplanner/assets/95319419/e2fe614c-4b06-4231-a602-9672530be294)

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Android Platform: emulation is carried out using Android Studio on Windows computer
iOS Platform: emulation is carried out using Xcode on MacBook

**Development Configuration**

Flutter version: 3.16.0
Dart version: 3.2.0

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas, if necessary
- [ ] I have made corresponding changes to the documentation, if necessary
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works, if necessary
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have Acceptance Tested this on an iOS device
- [x] I have Acceptance Tested this on an Android device
